### PR TITLE
Only enable tungstenite's "tls" feature when tokio-tungstenite's is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,17 @@ version = "0.2.1"
 [features]
 default = ["connect", "tls"]
 connect = ["tokio-dns-unofficial", "tokio-core", "stream"]
-tls = ["tokio-tls", "native-tls", "stream"]
+tls = ["tokio-tls", "native-tls", "stream", "tungstenite/tls"]
 stream = ["bytes"]
 
 [dependencies]
 futures = "0.1.13"
 tokio-io = "0.1.2"
-tungstenite = "0.2.4"
 url = "1.4.0"
+
+[dependencies.tungstenite]
+version = "0.2.4"
+default-features = false
 
 [dependencies.bytes]
 optional = true


### PR DESCRIPTION
Previously tungstenite was always built with its "tls" feature enabled (thus
pulling down native-tls), even when the tls feature wasn't enabled on
tokio-tungstenite. Here we modify Cargo.toml to have tungstenite default to no
active features, then enable the tungstenite/tls feature with
tokio-tungstenite's tls feature. The default configuration remains the same.