### PR TITLE
Expose danger_connect_async_without_providing_domain_for_certificate_verification_and_server_name_indication

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ use tungstenite::error::Error as WsError;
 use tungstenite::server;
 
 #[cfg(feature="connect")]
-pub use connect::{connect_async, client_async_tls};
+pub use connect::{connect_async, client_async_tls, danger_connect_async};
 
 /// Creates a WebSocket handshake from a request and a stream.
 /// For convenience, the user may call this with a url string, a URL,


### PR DESCRIPTION
With the absence of [Happy Eyeballs](https://tools.ietf.org/html/rfc8305) in Rust, I needed a way to disable certificate checking when trying to connect with an IP address instead of a URL.