### PR TITLE
Update to tungstenite-rs 0.5.4 so that WebSocketStream Sink implementation can apply back-pressure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ keywords = ["websocket", "io", "web"]
 authors = ["Daniel Abramov <dabramov@snapview.de>", "Alexey Galakhov <agalakhov@snapview.de>"]
 license = "MIT"
 homepage = "https://github.com/snapview/tokio-tungstenite"
-documentation = "https://docs.rs/tokio-tungstenite/0.5.1"
+documentation = "https://docs.rs/tokio-tungstenite/0.5.2"
 repository = "https://github.com/snapview/tokio-tungstenite"
-version = "0.5.1"
+version = "0.5.2"
 
 [features]
 default = ["connect", "tls"]
@@ -21,7 +21,7 @@ futures = "0.1.17"
 tokio-io = "0.1.2"
 
 [dependencies.tungstenite]
-version = "0.5.3"
+version = "0.5.4"
 default-features = false
 
 [dependencies.bytes]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,8 +127,7 @@ impl<T> Sink for WebSocketStream<T> where T: AsyncRead + AsyncWrite {
     type SinkError = WsError;
 
     fn start_send(&mut self, item: Message) -> StartSend<Message, WsError> {
-        try!(self.inner.write_message(item).to_async());
-        Ok(AsyncSink::Ready)
+        self.inner.write_message(item).to_start_send()
     }
 
     fn poll_complete(&mut self) -> Poll<(), WsError> {
@@ -216,6 +215,27 @@ impl<T> ToAsync for Result<T, WsError> {
             Ok(x) => Ok(Async::Ready(x)),
             Err(error) => match error {
                 WsError::Io(ref err) if err.kind() == ErrorKind::WouldBlock => Ok(Async::NotReady),
+                err => Err(err),
+            },
+        }
+    }
+}
+
+trait ToStartSend {
+    type T;
+    type E;
+    fn to_start_send(self) -> StartSend<Self::T, Self::E>;
+}
+
+impl ToStartSend for Result<(), (WsError, Option<Message>)> {
+    type T = Message;
+    type E = WsError;
+    fn to_start_send(self) -> StartSend<Self::T, Self::E> {
+        match self {
+            Ok(_) => Ok(AsyncSink::Ready),
+            Err((_, Some(msg))) => Ok(AsyncSink::NotReady(msg)),
+            Err((error, None)) => match error {
+                WsError::Io(ref err) if err.kind() == ErrorKind::WouldBlock => Ok(AsyncSink::Ready),
                 err => Err(err),
             },
         }


### PR DESCRIPTION
To fix #35