### PR TITLE
Add `MaybeTlsStream` wrapper type for streams that might be protected with TLS

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -39,10 +39,12 @@ mod encryption {
     use tungstenite::Error;
     use tungstenite::stream::Mode;
 
-    use stream::NoDelay;
+    use stream::{NoDelay, Stream as StreamSwitcher};
 
-    pub use stream::Stream as StreamSwitcher;
-    pub type AutoStream<S> = StreamSwitcher<S, TlsStream<S>>;
+    /// A stream that might be protected with TLS.
+    pub type MaybeTlsStream<S> = StreamSwitcher<S, TlsStream<S>>;
+
+    pub type AutoStream<S> = MaybeTlsStream<S>;
 
     impl<T: Read + Write + NoDelay> NoDelay for TlsStream<T> {
         fn set_nodelay(&mut self, nodelay: bool) -> IoResult<()> {
@@ -67,6 +69,9 @@ mod encryption {
         }
     }
 }
+
+#[cfg(feature="tls")]
+pub use self::encryption::MaybeTlsStream;
 
 #[cfg(not(feature="tls"))]
 mod encryption {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,9 @@ use tungstenite::{
 #[cfg(feature="connect")]
 pub use connect::{connect_async, client_async_tls};
 
+#[cfg(all(feature="connect", feature="tls"))]
+pub use connect::MaybeTlsStream;
+
 /// Creates a WebSocket handshake from a request and a stream.
 /// For convenience, the user may call this with a url string, a URL,
 /// or a `Request`. Calling with `Request` allows the user to add


### PR DESCRIPTION
Connecting to a URL wraps the connection into this wrapper type based on the protocol of the URL (`ws:` or `wss:`). Making this type public allows client applications to specify the websocket's type without importing the tokio_tls crate.

See also #44.

I chose to only export `OptionalTlsStream` if the `tls` feature is active, since its name and purpose doesn't make sense without TLS and may lead to confusion.
