### PR TITLE
Update comment to reflect current code

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -42,8 +42,8 @@ fn main() {
     let socket = TcpListener::bind(&addr).unwrap();
     println!("Listening on: {}", addr);
 
-    // This is a single-threaded server, so we can just use Rc and RefCell to
-    // store the map of all connections we know about.
+    // Tokio Runtime uses a thread pool based executor by default, so we need
+    // to use Arc and Mutex to store the map of all connections we know about.
     let connections = Arc::new(Mutex::new(HashMap::new()));
 
     let srv = socket.incoming().for_each(move |stream| {


### PR DESCRIPTION
After the code changes to support tokio reform, a comment on the server example [became outdated](https://github.com/snapview/tokio-tungstenite/commit/e2012633b43098430274cd490316d6f158e0d437#diff-bac3b8e7f9e4eb8c5c4f625b9ef7bd9bR47). This PR updates the comment to reflect the current state of the code.