### PR TITLE
Implement support to get the remote address

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -25,6 +25,7 @@ use futures::{Future, Sink, Stream};
 use tungstenite::protocol::Message;
 
 use tokio_tungstenite::connect_async;
+use tokio_tungstenite::stream::PeerAddr;
 
 fn main() {
     // Specify the server address to which the client will be connecting.
@@ -60,6 +61,9 @@ fn main() {
     let mut stdout = io::stdout();
     let client = connect_async(url).and_then(move |(ws_stream, _)| {
         println!("WebSocket handshake has been successfully completed");
+
+        let addr = ws_stream.peer_addr().expect("connected streams should have a peer address");
+        println!("Peer address: {}", addr);
 
         // `sink` is the stream of messages going out.
         // `stream` is the stream of incoming messages.

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -49,6 +49,7 @@ fn main() {
     let srv = socket.incoming().for_each(move |stream| {
 
         let addr = stream.peer_addr().expect("connected streams should have a peer address");
+        println!("Peer address: {}", addr);
 
         // We have to clone both of these values, because the `and_then`
         // function below constructs a new future, `and_then` requires

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,12 @@ pub mod stream;
 
 use std::io::ErrorKind;
 
+#[cfg(feature="stream")]
+use std::{
+    net::SocketAddr,
+    io::Result as IoResult,
+};
+
 use futures::{Poll, Future, Async, AsyncSink, Stream, Sink, StartSend};
 use tokio_io::{AsyncRead, AsyncWrite};
 
@@ -44,6 +50,9 @@ use tungstenite::{
 
 #[cfg(feature="connect")]
 pub use connect::{connect_async, client_async_tls};
+
+#[cfg(feature="stream")]
+pub use stream::PeerAddr;
 
 #[cfg(all(feature="connect", feature="tls"))]
 pub use connect::MaybeTlsStream;
@@ -191,6 +200,13 @@ impl<S> WebSocketStream<S> {
             inner: ws,
             stream_ended: false,
         }
+    }
+}
+
+#[cfg(feature="stream")]
+impl<S: PeerAddr> PeerAddr for WebSocketStream<S> {
+    fn peer_addr(&self) -> IoResult<SocketAddr> {
+        self.inner.get_ref().peer_addr()
     }
 }
 


### PR DESCRIPTION
This PR implements support for returning the remote address from the `WebSocketStream` by getting it from the underlying stream.