### PR TITLE
Automatically send a close frame when the WebSocketStream gets dropped

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,11 +168,11 @@ where
 /// through the respective `Stream` and `Sink`. Check more information about
 /// them in `futures-rs` crate documentation or have a look on the examples
 /// and unit tests for this crate.
-pub struct WebSocketStream<S> {
+pub struct WebSocketStream<S: AsyncRead + AsyncWrite> {
     inner: WebSocket<S>,
 }
 
-impl<S> WebSocketStream<S> {
+impl<S: AsyncRead + AsyncWrite> WebSocketStream<S> {
     /// Convert a raw socket into a WebSocketStream without performing a
     /// handshake.
     pub fn from_raw_socket(
@@ -201,8 +201,16 @@ impl<S> WebSocketStream<S> {
     }
 }
 
+impl<T> Drop for WebSocketStream<T> where T: AsyncRead + AsyncWrite
+{
+    fn drop( &mut self )
+    {
+        let _ = self.inner.close(None);
+    }
+}
+
 #[cfg(feature="stream")]
-impl<S: PeerAddr> PeerAddr for WebSocketStream<S> {
+impl<S: PeerAddr + AsyncRead + AsyncWrite> PeerAddr for WebSocketStream<S> {
     fn peer_addr(&self) -> IoResult<SocketAddr> {
         self.inner.get_ref().peer_addr()
     }


### PR DESCRIPTION
This might need some thinking and review. I don't know tokio-tungstenite well
enough to know how this will affect users, but it seems to me that it makes
sense to close the connection without a reason and code when the stream gets
dropped. Otherwise the other end will receive an error that the stream closed
without proper close frame. I feel that dropping is a normal flow, which does not constitute
an error, more so if the error can only be detected remotely.

This avoids having to manually close it always before drop. If this is considered
an error, then I think that it should be caught locally (eg panic in drop if
the connection hasn't been closed) instead of leaving an error to the remote side.

On the implementation. The close function does not seem to be available unless
the proper trait bounds are added. Unfortunately it doesn't seem possible to
create a partial drop impl, so for this to work they have to be added everywhere.

Maybe this is better implemented in tungstenite, but in any case it's annoying
if it's not at least in tokio-tungstenite, because further down the WebSocketStream
might be consumed by stream combinators, meaning that it might no longer be possible
to call close outside of async context. Drop is always outside async context except
if one spawns a future, or calls executor::block_on in order to call close. That seems
not a good alternative to me.