### PR TITLE
(tokio-)tungstenite allows sending data after the connection is closed

### DIFF
--- a/tests/close.rs
+++ b/tests/close.rs
@@ -1,0 +1,46 @@
+use std::io;
+
+use futures::{Future, Stream, Sink, Async};
+use tokio_tcp::{TcpListener, TcpStream};
+use tokio_tungstenite::{accept_async, client_async};
+use tungstenite::{Message};
+
+#[test]
+fn send_after_close() {
+    use std::sync::mpsc::channel;
+    use std::thread;
+
+    let (tx, rx) = channel();
+
+    thread::spawn(move || {
+        let address = "0.0.0.0:12346".parse().unwrap();
+        let listener = TcpListener::bind(&address).unwrap();
+        let connections = listener.incoming();
+        tx.send(()).unwrap();
+        let handshakes = connections.and_then(|connection| {
+            accept_async(connection).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        });
+        let server = handshakes.for_each(|stream| {
+            Stream::wait( stream ).for_each( |res| { dbg!( res ).expect( "for_each" ); });
+            Ok(())
+        });
+
+        server.wait().unwrap();
+    });
+
+    rx.recv().unwrap();
+    let address = "0.0.0.0:12346".parse().unwrap();
+    let tcp = TcpStream::connect(&address);
+    let handshake = tcp.and_then(|stream| {
+        let url = url::Url::parse("ws://localhost:12345/").unwrap();
+        client_async(url, stream).map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+    });
+    let client = handshake.and_then(|(mut stream, _response)| {
+        let res = stream.close().expect( "close connection" );
+        assert_eq!( res, Async::Ready(()) );
+        let res = stream.start_send( Message::Text("hi".to_owned()) );
+        assert!( res.is_err() );
+        Ok(())
+    });
+    client.wait().unwrap();
+}


### PR DESCRIPTION
This is a bugreport (no fix included).

I verified what happend when calling close on the Sink of WebSocketStream and then trying to send data. Given the websocket RFC specifically states no data should be sent after a close frame has been sent, I expected to get a `ConnectionClosed` or a `AlreadyClosed` error. It's not quite clear to me why there is 2 different error kinds here that seem applicable.

> A data frame MAY be transmitted by either the client or the server at any time after opening handshake completion and before that endpoint has sent a Close frame (Section 5.5.1).
_from: RFC 6455 - section 5.1.  Overview_

However the call to send returns an Ok value.

This commit includes an integration test demonstrating the issue.

I can also show this log (not from the code in the PR, but from an integration test on my own library). In this log we can see that tungstenite fully writes out the close frame, yet after that is willing to write out a data frame:
```shell
INFO [close] calling close
TRACE [ws_stream::ws_stream] WsStream: AsyncWrite - poll_flush
TRACE [ws_stream::ws_stream] flush AsyncWrite
TRACE [ws_stream::providers::tung_websocket] TungWebSocket: poll_flush
TRACE [tungstenite::protocol] Frames still in queue: 0
TRACE [ws_stream::ws_stream] Closing AsyncWrite
TRACE [ws_stream::providers::tung_websocket] TungWebSocket: poll_close
TRACE [tungstenite::protocol] Frames still in queue: 0
TRACE [tungstenite::protocol] Frames still in queue: 1
TRACE [tungstenite::protocol] Sending frame: Frame { header: FrameHeader { is_final: true, rsv1: false, rsv2: false, rsv3: false, opcode: Control(Close), mask: Some([229, 67, 210, 69]) }, payload: [] }
TRACE [tungstenite::protocol::frame] writing frame 
<FRAME>
final: true
reserved: false false false
opcode: CLOSE
length: 6
payload length: 0
payload: 0x
            
INFO [close] trying to send
TRACE [ws_stream::ws_stream] WsStream: AsyncWrite - poll_write
TRACE [ws_stream::ws_stream] WsStream: poll_write_impl called
TRACE [ws_stream::providers::tung_websocket] TungWebSocket: start_send
TRACE [ws_stream::providers::tung_websocket] TungWebSocket: poll_flush
TRACE [tungstenite::protocol] Frames still in queue: 1
TRACE [tungstenite::protocol] Sending frame: Frame { header: FrameHeader { is_final: true, rsv1: false, rsv2: false, rsv3: false, opcode: Data(Binary), mask: Some([35, 118, 245, 177]) }, payload: [97, 32, 108, 105, 110, 101, 10] }
TRACE [tungstenite::protocol::frame] writing frame 
<FRAME>
final: true
reserved: false false false
opcode: BINARY
length: 13
payload length: 7
payload: 0x61206c696e65a
            
TRACE [tungstenite::protocol] Frames still in queue: 0
TRACE [ws_stream::ws_stream] WsStream: poll_write_impl, wrote 7 bytes
TRACE [ws_stream::ws_stream] WsStream: AsyncWrite - poll_flush
TRACE [ws_stream::ws_stream] flush AsyncWrite
TRACE [ws_stream::providers::tung_websocket] TungWebSocket: poll_flush
TRACE [tungstenite::protocol] Frames still in queue: 0
TRACE [ws_stream::ws_stream] Drop WsStream
TRACE [ws_stream::ws_stream] Drop WsStream
test close_client ... FAILED
```  