### PR TITLE
 Use tokio::net::ToSocketAddrs instead of sync version from std

### DIFF
--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -3,7 +3,7 @@ use log::*;
 use tokio_tungstenite::{connect_async, tungstenite::Result};
 use url::Url;
 
-const AGENT: &'static str = "Tungstenite";
+const AGENT: &str = "Tungstenite";
 
 async fn get_case_count() -> Result<u32> {
     let (mut socket, _) =
@@ -49,7 +49,7 @@ async fn main() {
 
     let total = get_case_count().await.unwrap();
 
-    for case in 1..(total + 1) {
+    for case in 1..=total {
         run_test(case).await
     }
 

--- a/examples/autobahn-server.rs
+++ b/examples/autobahn-server.rs
@@ -1,6 +1,6 @@
 use futures::{SinkExt, StreamExt};
 use log::*;
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_tungstenite::accept_async;
 
@@ -21,11 +21,7 @@ async fn accept_connection(peer: SocketAddr, stream: TcpStream) {
 async fn main() {
     env_logger::init();
 
-    let addr = "127.0.0.1:9002"
-        .to_socket_addrs()
-        .expect("Not a valid address")
-        .next()
-        .expect("Not a socket address");
+    let addr = "127.0.0.1:9002";
     let mut listener = TcpListener::bind(&addr).await.unwrap();
     info!("Listening on: {}", addr);
 

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -36,7 +36,7 @@ async fn main() {
 
     let (write, read) = ws_stream.split();
 
-    let stdin_to_ws = stdin_rx.map(|msg| Ok(msg)).forward(write);
+    let stdin_to_ws = stdin_rx.map(Ok).forward(write);
     let ws_to_stdout = {
         read.for_each(|message| {
             async {

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -12,7 +12,7 @@
 
 use std::env;
 
-use futures::{future, pin_mut, SinkExt, StreamExt};
+use futures::{future, pin_mut, StreamExt};
 use log::info;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_tungstenite::connect_async;

--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -8,7 +8,7 @@
 //!
 //!     cargo run --example client ws://127.0.0.1:12345/
 
-use std::{env, io::Error, net::ToSocketAddrs};
+use std::{env, io::Error};
 
 use futures::StreamExt;
 use log::info;
@@ -18,11 +18,6 @@ use tokio::net::{TcpListener, TcpStream};
 async fn main() -> Result<(), Error> {
     let _ = env_logger::try_init();
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
-    let addr = addr
-        .to_socket_addrs()
-        .expect("Not a valid address")
-        .next()
-        .expect("Not a socket address");
 
     // Create the event loop and TCP listener we'll accept connections on.
     let try_socket = TcpListener::bind(&addr).await;

--- a/examples/echo-server.rs
+++ b/examples/echo-server.rs
@@ -17,7 +17,9 @@ use tokio::net::{TcpListener, TcpStream};
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     let _ = env_logger::try_init();
-    let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
+    let addr = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:8080".to_string());
 
     // Create the event loop and TCP listener we'll accept connections on.
     let try_socket = TcpListener::bind(&addr).await;

--- a/tests/communication.rs
+++ b/tests/communication.rs
@@ -1,6 +1,5 @@
 use futures::{SinkExt, StreamExt};
 use log::*;
-use std::net::ToSocketAddrs;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_tungstenite::{accept_async, client_async, WebSocketStream};
@@ -31,12 +30,7 @@ async fn communication() {
     let (msg_tx, msg_rx) = futures::channel::oneshot::channel();
 
     let f = async move {
-        let address = "0.0.0.0:12345"
-            .to_socket_addrs()
-            .expect("Not a valid address")
-            .next()
-            .expect("No address resolved");
-        let mut listener = TcpListener::bind(&address).await.unwrap();
+        let mut listener = TcpListener::bind("0.0.0.0:12345").await.unwrap();
         info!("Server ready");
         con_tx.send(()).unwrap();
         info!("Waiting on next connection");
@@ -51,12 +45,7 @@ async fn communication() {
     info!("Waiting for server to be ready");
 
     con_rx.await.expect("Server not ready");
-    let address = "0.0.0.0:12345"
-        .to_socket_addrs()
-        .expect("Not a valid address")
-        .next()
-        .expect("No address resolved");
-    let tcp = TcpStream::connect(&address)
+    let tcp = TcpStream::connect("0.0.0.0:12345")
         .await
         .expect("Failed to connect");
     let url = url::Url::parse("ws://localhost:12345/").unwrap();
@@ -87,12 +76,7 @@ async fn split_communication() {
     let (msg_tx, msg_rx) = futures::channel::oneshot::channel();
 
     let f = async move {
-        let address = "0.0.0.0:12346"
-            .to_socket_addrs()
-            .expect("Not a valid address")
-            .next()
-            .expect("No address resolved");
-        let mut listener = TcpListener::bind(&address).await.unwrap();
+        let mut listener = TcpListener::bind("0.0.0.0:12346").await.unwrap();
         info!("Server ready");
         con_tx.send(()).unwrap();
         info!("Waiting on next connection");
@@ -107,12 +91,7 @@ async fn split_communication() {
     info!("Waiting for server to be ready");
 
     con_rx.await.expect("Server not ready");
-    let address = "0.0.0.0:12346"
-        .to_socket_addrs()
-        .expect("Not a valid address")
-        .next()
-        .expect("No address resolved");
-    let tcp = TcpStream::connect(&address)
+    let tcp = TcpStream::connect("0.0.0.0:12346")
         .await
         .expect("Failed to connect");
     let url = url::Url::parse("ws://localhost:12345/").unwrap();

--- a/tests/handshakes.rs
+++ b/tests/handshakes.rs
@@ -1,4 +1,3 @@
-use std::net::ToSocketAddrs;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_tungstenite::{accept_async, client_async};
 
@@ -7,12 +6,7 @@ async fn handshakes() {
     let (tx, rx) = futures::channel::oneshot::channel();
 
     let f = async move {
-        let address = "0.0.0.0:12345"
-            .to_socket_addrs()
-            .expect("Not a valid address")
-            .next()
-            .expect("No address resolved");
-        let mut listener = TcpListener::bind(&address).await.unwrap();
+        let mut listener = TcpListener::bind("0.0.0.0:12345").await.unwrap();
         tx.send(()).unwrap();
         while let Ok((connection, _)) = listener.accept().await {
             let stream = accept_async(connection).await;
@@ -23,12 +17,7 @@ async fn handshakes() {
     tokio::spawn(f);
 
     rx.await.expect("Failed to wait for server to be ready");
-    let address = "0.0.0.0:12345"
-        .to_socket_addrs()
-        .expect("Not a valid address")
-        .next()
-        .expect("No address resolved");
-    let tcp = TcpStream::connect(&address)
+    let tcp = TcpStream::connect("0.0.0.0:12345")
         .await
         .expect("Failed to connect");
     let url = url::Url::parse("ws://localhost:12345/").unwrap();


### PR DESCRIPTION
And fix a couple of clippy warnings while we're at it.