### PR TITLE
Add example of server periodically updating client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,6 @@ optional = true
 version = "0.3"
 
 [dev-dependencies]
-tokio = { version = "0.2", default-features = false, features = ["io-std", "macros"] }
+tokio = { version = "0.2", default-features = false, features = ["io-std", "macros", "stream", "time"] }
 url = "2.0.0"
 env_logger = "0.7"

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,3 +5,4 @@ Examples
 * [client.rs](https://github.com/snapview/tokio-tungstenite/blob/master/examples/client.rs)
 * [echo-server.rs](https://github.com/snapview/tokio-tungstenite/blob/master/examples/echo-server.rs)
 * [server.rs](https://github.com/snapview/tokio-tungstenite/blob/master/examples/server.rs)
+* [interval-server.rs](https://github.com/snapview/tokio-tungstenite/blob/master/examples/interval-server.rs)

--- a/examples/interval-server.rs
+++ b/examples/interval-server.rs
@@ -1,0 +1,73 @@
+use futures::future::{select, Either};
+use futures::{SinkExt, StreamExt};
+use log::*;
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{accept_async, tungstenite::Error};
+use tungstenite::{Message, Result};
+
+async fn accept_connection(peer: SocketAddr, stream: TcpStream) {
+    if let Err(e) = handle_connection(peer, stream).await {
+        match e {
+            Error::ConnectionClosed | Error::Protocol(_) | Error::Utf8 => (),
+            err => error!("Error processing connection: {}", err),
+        }
+    }
+}
+
+async fn handle_connection(peer: SocketAddr, stream: TcpStream) -> Result<()> {
+    let ws_stream = accept_async(stream).await.expect("Failed to accept");
+    info!("New WebSocket connection: {}", peer);
+    let (mut ws_sender, mut ws_receiver) = ws_stream.split();
+    let mut interval = tokio::time::interval(Duration::from_millis(1000));
+    
+    // Echo incoming WebSocket messages and send a message periodically every second.
+
+    let mut msg_fut = ws_receiver.next();
+    let mut tick_fut = interval.next();
+    loop {
+        match select(msg_fut, tick_fut).await {
+            Either::Left((msg, tick_fut_continue)) => {
+                match msg {
+                    Some(msg) => {
+                        let msg = msg?;
+                        if msg.is_text() || msg.is_binary() {
+                            ws_sender.send(msg).await?;
+                        } else if msg.is_close() {
+                            break;
+                        }
+                        tick_fut = tick_fut_continue; // Continue waiting for tick.
+                        msg_fut = ws_receiver.next(); // Receive next WebSocket message.
+                    }
+                    None => break, // WebSocket stream terminated.
+                };
+            }
+            Either::Right((_, msg_fut_continue)) => {
+                ws_sender.send(Message::Text("tick".to_owned())).await?;
+                msg_fut = msg_fut_continue; // Continue receiving the WebSocket message.
+                tick_fut = interval.next(); // Wait for next tick.
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let addr = "127.0.0.1:9002";
+    let mut listener = TcpListener::bind(&addr).await.expect("Can't listen");
+    info!("Listening on: {}", addr);
+
+    while let Ok((stream, _)) = listener.accept().await {
+        let peer = stream
+            .peer_addr()
+            .expect("connected streams should have a peer address");
+        info!("Peer address: {}", peer);
+
+        tokio::spawn(accept_connection(peer, stream));
+    }
+}


### PR DESCRIPTION
Example from issue #82 

This example shows how to both handle WebSocket messages and send updates to the client periodically.

A real world example would be a dashboard application that lets the user send commands in a request/response model but also updates the dashboard's stats periodically.