### PR TITLE
Fix clippy warning about ok_or() followed by a function call

### DIFF
--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -1,6 +1,6 @@
 use futures::{SinkExt, StreamExt};
 use log::*;
-use tokio_tungstenite::{connect_async, tungstenite::Result, tungstenite::Error};
+use tokio_tungstenite::{connect_async, tungstenite::Error, tungstenite::Result};
 use url::Url;
 
 const AGENT: &str = "Tungstenite";

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -35,11 +35,9 @@ async fn main() {
 
     let stdin_to_ws = stdin_rx.map(Ok).forward(write);
     let ws_to_stdout = {
-        read.for_each(|message| {
-            async {
-                let data = message.unwrap().into_data();
-                tokio::io::stdout().write_all(&data).await.unwrap();
-            }
+        read.for_each(|message| async {
+            let data = message.unwrap().into_data();
+            tokio::io::stdout().write_all(&data).await.unwrap();
         })
     };
 

--- a/examples/interval-server.rs
+++ b/examples/interval-server.rs
@@ -21,7 +21,7 @@ async fn handle_connection(peer: SocketAddr, stream: TcpStream) -> Result<()> {
     info!("New WebSocket connection: {}", peer);
     let (mut ws_sender, mut ws_receiver) = ws_stream.split();
     let mut interval = tokio::time::interval(Duration::from_millis(1000));
-    
+
     // Echo incoming WebSocket messages and send a message periodically every second.
 
     let mut msg_fut = ws_receiver.next();

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -6,7 +6,7 @@ use tungstenite::client::uri_mode;
 use tungstenite::handshake::client::Response;
 use tungstenite::Error;
 
-use super::{client_async, Request, IntoClientRequest, WebSocketStream};
+use super::{client_async, IntoClientRequest, Request, WebSocketStream};
 
 #[cfg(feature = "tls")]
 pub(crate) mod encryption {
@@ -122,12 +122,10 @@ where
     let port = request
         .uri()
         .port_u16()
-        .or_else(|| {
-            match request.uri().scheme_str() {
-                Some("wss") => Some(443),
-                Some("ws") => Some(80),
-                _ => None
-            }
+        .or_else(|| match request.uri().scheme_str() {
+            Some("wss") => Some(443),
+            Some("ws") => Some(80),
+            _ => None,
         })
         .ok_or_else(|| Error::Url("Url scheme not supported".into()))?;
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -129,7 +129,7 @@ where
                 _ => None
             }
         })
-        .ok_or(Error::Url("Url scheme not supported".into()))?;
+        .ok_or_else(|| Error::Url("Url scheme not supported".into()))?;
 
     let addr = format!("{}:{}", domain, port);
     let try_socket = TcpStream::connect(addr).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use tungstenite::{
-    error::Error as WsError,
     client::IntoClientRequest,
+    error::Error as WsError,
     handshake::{
         client::{ClientHandshake, Request, Response},
         server::{Callback, NoCallback},


### PR DESCRIPTION
    warning: use of `ok_or` followed by a function call
       --> src/connect.rs:132:10
        |
    132 |         .ok_or(Error::Url("Url scheme not supported".into()))?;
        |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `ok_or_else(|| Error::Url("Url scheme not supported".into()))`
