### PR TITLE
Don't require Unpin when pin projecting.

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -18,7 +18,7 @@ pub enum Stream<S, T> {
     Tls(#[pin] T),
 }
 
-impl<S: AsyncRead + Unpin, T: AsyncRead + Unpin> AsyncRead for Stream<S, T> {
+impl<S: AsyncRead, T: AsyncRead> AsyncRead for Stream<S, T> {
     #[project]
     fn poll_read(
         self: Pin<&mut Self>,
@@ -27,13 +27,13 @@ impl<S: AsyncRead + Unpin, T: AsyncRead + Unpin> AsyncRead for Stream<S, T> {
     ) -> Poll<std::io::Result<usize>> {
         #[project]
         match self.project() {
-            Stream::Plain(ref mut s) => Pin::new(s).poll_read(cx, buf),
-            Stream::Tls(ref mut s) => Pin::new(s).poll_read(cx, buf),
+            Stream::Plain(s) => s.poll_read(cx, buf),
+            Stream::Tls(s) => s.poll_read(cx, buf),
         }
     }
 }
 
-impl<S: AsyncWrite + Unpin, T: AsyncWrite + Unpin> AsyncWrite for Stream<S, T> {
+impl<S: AsyncWrite, T: AsyncWrite> AsyncWrite for Stream<S, T> {
     #[project]
     fn poll_write(
         self: Pin<&mut Self>,
@@ -42,8 +42,8 @@ impl<S: AsyncWrite + Unpin, T: AsyncWrite + Unpin> AsyncWrite for Stream<S, T> {
     ) -> Poll<Result<usize, std::io::Error>> {
         #[project]
         match self.project() {
-            Stream::Plain(ref mut s) => Pin::new(s).poll_write(cx, buf),
-            Stream::Tls(ref mut s) => Pin::new(s).poll_write(cx, buf),
+            Stream::Plain(s) => s.poll_write(cx, buf),
+            Stream::Tls(s) => s.poll_write(cx, buf),
         }
     }
 
@@ -51,8 +51,8 @@ impl<S: AsyncWrite + Unpin, T: AsyncWrite + Unpin> AsyncWrite for Stream<S, T> {
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
         #[project]
         match self.project() {
-            Stream::Plain(ref mut s) => Pin::new(s).poll_flush(cx),
-            Stream::Tls(ref mut s) => Pin::new(s).poll_flush(cx),
+            Stream::Plain(s) => s.poll_flush(cx),
+            Stream::Tls(s) => s.poll_flush(cx),
         }
     }
 
@@ -63,8 +63,8 @@ impl<S: AsyncWrite + Unpin, T: AsyncWrite + Unpin> AsyncWrite for Stream<S, T> {
     ) -> Poll<Result<(), std::io::Error>> {
         #[project]
         match self.project() {
-            Stream::Plain(ref mut s) => Pin::new(s).poll_shutdown(cx),
-            Stream::Tls(ref mut s) => Pin::new(s).poll_shutdown(cx),
+            Stream::Plain(s) => s.poll_shutdown(cx),
+            Stream::Tls(s) => s.poll_shutdown(cx),
         }
     }
 }


### PR DESCRIPTION
There are two scenarios here. Either you want users to be able to pass in
streams that are `!Unpin`, in which case pin_project and the compiler
have your back and make sure this works, or...

You are going to require Unpin on it in which case you can remove the pin
projection. -> See #90 

Both together don't make sense. Either one works here, but by removing the
Unpin the API is less restrictive, which I would favor, even if I don't
immediately see what concrete `!Unpin` type someone might want to call this with,
but sooner or later someone probably will, so why disable if it can work.

This leaves another problem though, there are many other places in the lib
where `Unpin` is required, notably on the wrappers around `Stream`, so it's
not said that with this change users can actually use any `!Unpin` streams.

There is one other use of pin-project on `MidHandshake`. As far as I can
tell the effect of this one is that `Role::InternalStream` can now be `!Unpin`
in this specific file, but is it even possible to use the lib with an `!Unpin`
type for this?

It looks like it might be good to rethink the choices about pin for the
entire lib and make something consistent. Maybe aim for the largest API
compatibility by trying to never require `Unpin` and seeing if pin-project
makes that possible.

In any case, the Unpin in `Stream` has no good reason for being there unless
you would like to get rid of pin-project.

As an added bonus, if you pin project, there is no need for re-pinning in the match.