### PR TITLE
Don't project if you require Unpin.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ stream = []
 [dependencies]
 log = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
-pin-project = "0.4"
 tokio = { version = "0.2", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3,30 +3,26 @@
 //!  There is no dependency on actual TLS implementations. Everything like
 //! `native_tls` or `openssl` will work as long as there is a TLS stream supporting standard
 //! `Read + Write` traits.
-use pin_project::{pin_project, project};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Stream, either plain TCP or TLS.
-#[pin_project]
 pub enum Stream<S, T> {
     /// Unencrypted socket stream.
-    Plain(#[pin] S),
+    Plain(S),
     /// Encrypted socket stream.
-    Tls(#[pin] T),
+    Tls(T),
 }
 
 impl<S: AsyncRead + Unpin, T: AsyncRead + Unpin> AsyncRead for Stream<S, T> {
-    #[project]
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<std::io::Result<usize>> {
-        #[project]
-        match self.project() {
+        match self.get_mut() {
             Stream::Plain(ref mut s) => Pin::new(s).poll_read(cx, buf),
             Stream::Tls(ref mut s) => Pin::new(s).poll_read(cx, buf),
         }
@@ -34,35 +30,29 @@ impl<S: AsyncRead + Unpin, T: AsyncRead + Unpin> AsyncRead for Stream<S, T> {
 }
 
 impl<S: AsyncWrite + Unpin, T: AsyncWrite + Unpin> AsyncWrite for Stream<S, T> {
-    #[project]
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
-        #[project]
-        match self.project() {
+        match self.get_mut() {
             Stream::Plain(ref mut s) => Pin::new(s).poll_write(cx, buf),
             Stream::Tls(ref mut s) => Pin::new(s).poll_write(cx, buf),
         }
     }
 
-    #[project]
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
-        #[project]
-        match self.project() {
+        match self.get_mut() {
             Stream::Plain(ref mut s) => Pin::new(s).poll_flush(cx),
             Stream::Tls(ref mut s) => Pin::new(s).poll_flush(cx),
         }
     }
 
-    #[project]
     fn poll_shutdown(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
-        #[project]
-        match self.project() {
+        match self.get_mut() {
             Stream::Plain(ref mut s) => Pin::new(s).poll_shutdown(cx),
             Stream::Tls(ref mut s) => Pin::new(s).poll_shutdown(cx),
         }


### PR DESCRIPTION
This is the counter proposition of #89. Since it's rather convoluted to remove the `Unpin` requirement on the underlying stream users can wrap in `WebSocketStream` and I don't know of any use cases for it, I propose to keep the `Unpin` and consequently remove pin-projection from tokio-tungstenite. This also sheds a dependency.

The first commit is completely self contained. Nothing outside of this file will observe any difference. I think it's good to apply it no matter what except if choosing to remove Unpin bounds everywhere as discussed in #89. 

The second is a bit more complicated. It's concerned with the handshake, which takes place before there even is a `WebSocketStream`. There is a type `Role::InternalStream`, which comes from tungstenite, which uses trait bounds `Read + Write` and doesn't mention `Unpin`. The current state allowed this type to be `!Unpin`, although I suspect that normally this is the same underlying connection that is used for wrapping in `WebSocketStream`, so there probably already wasn't any way for users to pass a `!Unpin` type in here. 

However, I haven't actually tested this assumption. If the assumption holds, I suppose this is not a breaking change. If it changes what people could pass in, it is a breaking change.