### PR TITLE
Forward handshake errors directly instead of wrapping them in a Other…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ use tungstenite::{
     handshake::{
         client::{ClientHandshake, Request, Response},
         server::{Callback, NoCallback},
+        HandshakeError,
     },
     protocol::{Message, Role, WebSocket, WebSocketConfig},
     server,
@@ -94,11 +95,12 @@ where
         let cli_handshake = ClientHandshake::start(allow_std, request, config)?;
         cli_handshake.handshake()
     });
-    f.await.map_err(|e| {
-        WsError::Io(std::io::Error::new(
+    f.await.map_err(|e| match e {
+        HandshakeError::Failure(e) => e,
+        e => WsError::Io(std::io::Error::new(
             std::io::ErrorKind::Other,
             e.to_string(),
-        ))
+        )),
     })
 }
 
@@ -159,11 +161,12 @@ where
     let f = handshake::server_handshake(stream, move |allow_std| {
         server::accept_hdr_with_config(allow_std, callback, config)
     });
-    f.await.map_err(|e| {
-        WsError::Io(std::io::Error::new(
+    f.await.map_err(|e| match e {
+        HandshakeError::Failure(e) => e,
+        e => WsError::Io(std::io::Error::new(
             std::io::ErrorKind::Other,
             e.to_string(),
-        ))
+        )),
     })
 }
 


### PR DESCRIPTION
… IO error

This allows getting HTTP status codes back to the caller, for example,
and allows proper handling of handshake errors.

Fixes https://github.com/snapview/tokio-tungstenite/issues/97