### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ stream = []
 [dependencies]
 log = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
-pin-project = "0.4"
+pin-project = "0.4.17"
 tokio = { version = "0.2", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -3,14 +3,14 @@
 //!  There is no dependency on actual TLS implementations. Everything like
 //! `native_tls` or `openssl` will work as long as there is a TLS stream supporting standard
 //! `Read + Write` traits.
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Stream, either plain TCP or TLS.
-#[pin_project]
+#[pin_project(project = StreamProj)]
 pub enum Stream<S, T> {
     /// Unencrypted socket stream.
     Plain(#[pin] S),
@@ -19,52 +19,44 @@ pub enum Stream<S, T> {
 }
 
 impl<S: AsyncRead + Unpin, T: AsyncRead + Unpin> AsyncRead for Stream<S, T> {
-    #[project]
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<std::io::Result<usize>> {
-        #[project]
         match self.project() {
-            Stream::Plain(ref mut s) => Pin::new(s).poll_read(cx, buf),
-            Stream::Tls(ref mut s) => Pin::new(s).poll_read(cx, buf),
+            StreamProj::Plain(ref mut s) => Pin::new(s).poll_read(cx, buf),
+            StreamProj::Tls(ref mut s) => Pin::new(s).poll_read(cx, buf),
         }
     }
 }
 
 impl<S: AsyncWrite + Unpin, T: AsyncWrite + Unpin> AsyncWrite for Stream<S, T> {
-    #[project]
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
-        #[project]
         match self.project() {
-            Stream::Plain(ref mut s) => Pin::new(s).poll_write(cx, buf),
-            Stream::Tls(ref mut s) => Pin::new(s).poll_write(cx, buf),
+            StreamProj::Plain(ref mut s) => Pin::new(s).poll_write(cx, buf),
+            StreamProj::Tls(ref mut s) => Pin::new(s).poll_write(cx, buf),
         }
     }
 
-    #[project]
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
-        #[project]
         match self.project() {
-            Stream::Plain(ref mut s) => Pin::new(s).poll_flush(cx),
-            Stream::Tls(ref mut s) => Pin::new(s).poll_flush(cx),
+            StreamProj::Plain(ref mut s) => Pin::new(s).poll_flush(cx),
+            StreamProj::Tls(ref mut s) => Pin::new(s).poll_flush(cx),
         }
     }
 
-    #[project]
     fn poll_shutdown(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
-        #[project]
         match self.project() {
-            Stream::Plain(ref mut s) => Pin::new(s).poll_shutdown(cx),
-            Stream::Tls(ref mut s) => Pin::new(s).poll_shutdown(cx),
+            StreamProj::Plain(ref mut s) => Pin::new(s).poll_shutdown(cx),
+            StreamProj::Tls(ref mut s) => Pin::new(s).poll_shutdown(cx),
         }
     }
 }


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*