### PR TITLE
Add the option to configure the TLS connection.

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -11,7 +11,7 @@ use super::{client_async_with_config, IntoClientRequest, Request, WebSocketStrea
 
 #[cfg(feature = "tls")]
 pub(crate) mod encryption {
-    use native_tls::TlsConnector;
+    use native_tls::TlsConnector as NativeTlsConnector;
     use tokio_native_tls::{TlsConnector as TokioTlsConnector, TlsStream};
 
     use tokio::io::{AsyncRead, AsyncWrite};
@@ -26,10 +26,14 @@ pub(crate) mod encryption {
 
     pub type AutoStream<S> = MaybeTlsStream<S>;
 
+    /// A TLS connector that can be used when establishing TLS connections.
+    pub type TlsConnector = NativeTlsConnector;
+
     pub async fn wrap_stream<S>(
         socket: S,
         domain: String,
         mode: Mode,
+        tls_connector: Option<TlsConnector>,
     ) -> Result<AutoStream<S>, Error>
     where
         S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
@@ -37,7 +41,7 @@ pub(crate) mod encryption {
         match mode {
             Mode::Plain => Ok(StreamSwitcher::Plain(socket)),
             Mode::Tls => {
-                let try_connector = TlsConnector::new();
+                let try_connector = tls_connector.map_or_else(|| TlsConnector::new(), |c| Ok(c));
                 let connector = try_connector.map_err(Error::Tls)?;
                 let stream = TokioTlsConnector::from(connector);
                 let connected = stream.connect(&domain, socket).await;
@@ -53,6 +57,8 @@ pub(crate) mod encryption {
 #[cfg(feature = "tls")]
 pub use self::encryption::MaybeTlsStream;
 
+pub use self::encryption::TlsConnector;
+
 #[cfg(not(feature = "tls"))]
 pub(crate) mod encryption {
     use tokio::io::{AsyncRead, AsyncWrite};
@@ -62,10 +68,14 @@ pub(crate) mod encryption {
 
     pub type AutoStream<S> = S;
 
+    /// A TLS connector that can be used when establishing TLS connections.
+    pub type TlsConnector = ();
+
     pub async fn wrap_stream<S>(
         socket: S,
         _domain: String,
         mode: Mode,
+        _tls_connector: Option<TlsConnector>,
     ) -> Result<AutoStream<S>, Error>
     where
         S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
@@ -99,15 +109,18 @@ where
     S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
     AutoStream<S>: Unpin,
 {
-    client_async_tls_with_config(request, stream, None).await
+    client_async_tls_with_config(request, stream, None, None).await
 }
 
-/// The same as `client_async_tls()` but the one can specify a websocket configuration.
+/// The same as `client_async_tls()` but the one can specify a websocket configuration, and a
+/// TLS connector.
+///
 /// Please refer to `client_async_tls()` for more details.
 pub async fn client_async_tls_with_config<R, S>(
     request: R,
     stream: S,
-    config: Option<WebSocketConfig>
+    config: Option<WebSocketConfig>,
+    tls_connector: Option<TlsConnector>,
 ) -> Result<(WebSocketStream<AutoStream<S>>, Response), Error>
 where
     R: IntoClientRequest + Unpin,
@@ -121,13 +134,13 @@ where
     // Make sure we check domain and mode first. URL must be valid.
     let mode = uri_mode(&request.uri())?;
 
-    let stream = wrap_stream(stream, domain, mode).await?;
+    let stream = wrap_stream(stream, domain, mode, tls_connector).await?;
     client_async_with_config(request, stream, config).await
 }
 
 /// Connect to a given URL.
 pub async fn connect_async<R>(
-    request: R
+    request: R,
 ) -> Result<(WebSocketStream<AutoStream<TcpStream>>, Response), Error>
 where
     R: IntoClientRequest + Unpin,
@@ -139,7 +152,7 @@ where
 /// Please refer to `connect_async()` for more details.
 pub async fn connect_async_with_config<R>(
     request: R,
-    config: Option<WebSocketConfig>
+    config: Option<WebSocketConfig>,
 ) -> Result<(WebSocketStream<AutoStream<TcpStream>>, Response), Error>
 where
     R: IntoClientRequest + Unpin,
@@ -160,5 +173,5 @@ where
     let addr = format!("{}:{}", domain, port);
     let try_socket = TcpStream::connect(addr).await;
     let socket = try_socket.map_err(Error::Io)?;
-    client_async_tls_with_config(request, socket, config).await
+    client_async_tls_with_config(request, socket, config, None).await
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -112,8 +112,9 @@ where
     client_async_tls_with_config(request, stream, None, None).await
 }
 
-/// The same as `client_async_tls()` but the one can specify a websocket configuration, and a
-/// TLS connector.
+/// The same as `client_async_tls()` but the one can specify a websocket configuration,
+/// and an optional TLS connector. If no connector is specified, the default one will
+/// be created.
 ///
 /// Please refer to `client_async_tls()` for more details.
 pub async fn client_async_tls_with_config<R, S>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,11 @@ use tungstenite::{
 
 #[cfg(feature = "connect")]
 pub use connect::{
-    client_async_tls, 
-    client_async_tls_with_config, 
+    client_async_tls,
+    client_async_tls_with_config,
     connect_async,
-    connect_async_with_config
+    connect_async_with_config,
+    TlsConnector,
 };
 
 #[cfg(all(feature = "connect", feature = "tls"))]


### PR DESCRIPTION
This PR addresses #111. 

Instead of exposing a `danger_client_async_tls` function, I've decided to add the option to pass a `TlsConnector` to `client_async_tls_with_config` (which will enable people to add root certificates to the connector, or disable certificate validation altogether).

I'm happy to some up with a different solution if you disagree with this change.