### PR TITLE
Fixed not to send Close frame at `poll_close`

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -58,4 +58,6 @@ async fn read_stdin(tx: futures_channel::mpsc::UnboundedSender<Message>) {
         buf.truncate(n);
         tx.unbounded_send(Message::binary(buf)).unwrap();
     }
+
+    tx.unbounded_send(Message::Close(None)).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ where
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        match (*self).with_context(Some((ContextWaker::Write, cx)), |s| s.close(None)) {
+        match (*self).with_context(Some((ContextWaker::Write, cx)), |_| Ok(())) {
             Ok(()) => Poll::Ready(Ok(())),
             Err(::tungstenite::Error::ConnectionClosed) => Poll::Ready(Ok(())),
             Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,15 +323,8 @@ where
         (*self).with_context(Some((ContextWaker::Write, cx)), |s| cvt(s.write_pending()))
     }
 
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        match (*self).with_context(Some((ContextWaker::Write, cx)), |_| Ok(())) {
-            Ok(()) => Poll::Ready(Ok(())),
-            Err(::tungstenite::Error::ConnectionClosed) => Poll::Ready(Ok(())),
-            Err(err) => {
-                debug!("websocket close error: {}", err);
-                Poll::Ready(Err(err))
-            }
-        }
+    fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
     }
 }
 

--- a/tests/communication.rs
+++ b/tests/communication.rs
@@ -94,7 +94,7 @@ async fn split_communication() {
     let tcp = TcpStream::connect("0.0.0.0:12346")
         .await
         .expect("Failed to connect");
-    let url = url::Url::parse("ws://localhost:12345/").unwrap();
+    let url = url::Url::parse("ws://localhost:12346/").unwrap();
     let (stream, _) = client_async(url, tcp)
         .await
         .expect("Client failed to connect");
@@ -107,7 +107,7 @@ async fn split_communication() {
             .expect("Failed to send message");
     }
 
-    tx.close().await.expect("Failed to close");
+    tx.send(Message::Close(None)).await.expect("Failed to close");
 
     info!("Waiting for response messages");
     let messages = msg_rx.await.expect("Failed to receive messages");


### PR DESCRIPTION
In version 0.11.0, the Close frame is automatically sent in the `poll_close` method of `Sink`. However, when using WebSocket, there are cases that the processing result from the server is received asynchronously with sending data from the client. (For example, in the case of voice recognition, the voice stream is sent and then the processing result of the server is received.)

For such a case, I thought that the process of automatically sending a Close frame should be removed from the crate and explicitly described on the application, so I modified it.