### PR TITLE
Upgrade to tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,13 @@ stream = []
 log = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
 pin-project = "1.0"
-tokio = { version = "0.3", default-features = false, features = ["io-util"] }
+tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
 version = "0.11.1"
 default-features = false
+git = "https://github.com/nickelc/tungstenite-rs.git"
+branch = "bytes"
 
 [dependencies.native-tls]
 optional = true
@@ -34,9 +36,11 @@ version = "0.2.0"
 [dependencies.tokio-native-tls]
 optional = true
 version = "0.2"
+git = "https://github.com/tokio-rs/tls.git"
+rev = "44e978cfa6e46294c0e352fad820456dbe94bdaa"
 
 [dev-dependencies]
 futures-channel = "0.3"
-tokio = { version = "0.3", default-features = false, features = ["io-std", "macros", "rt-multi-thread", "stream", "time"] }
+tokio = { version = "1.0.0", default-features = false, features = ["io-std", "macros", "rt-multi-thread", "time"] }
 url = "2.0.0"
 env_logger = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,8 @@ pin-project = "1.0"
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
-version = "0.11.1"
+version = "0.12.0"
 default-features = false
-git = "https://github.com/snapview/tungstenite-rs.git"
-rev = "208061ba284eaf95a54c1b9b6968f570004c90de"
 
 [dependencies.native-tls]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 [dependencies.tungstenite]
 version = "0.11.1"
 default-features = false
-git = "https://github.com/nickelc/tungstenite-rs.git"
-branch = "bytes"
+git = "https://github.com/snapview/tungstenite-rs.git"
+rev = "208061ba284eaf95a54c1b9b6968f570004c90de"
 
 [dependencies.native-tls]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,7 @@ version = "0.2.0"
 
 [dependencies.tokio-native-tls]
 optional = true
-version = "0.2"
-git = "https://github.com/tokio-rs/tls.git"
-rev = "44e978cfa6e46294c0e352fad820456dbe94bdaa"
+version = "0.3.0"
 
 [dev-dependencies]
 futures-channel = "0.3"

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -92,11 +92,11 @@ pub(crate) async fn client_handshake<F, S>(
 ) -> Result<(WebSocketStream<S>, Response), Error<ClientHandshake<AllowStd<S>>>>
 where
     F: FnOnce(
-            AllowStd<S>,
-        ) -> Result<
-            <ClientHandshake<AllowStd<S>> as HandshakeRole>::FinalResult,
-            Error<ClientHandshake<AllowStd<S>>>,
-        > + Unpin,
+        AllowStd<S>,
+    ) -> Result<
+        <ClientHandshake<AllowStd<S>> as HandshakeRole>::FinalResult,
+        Error<ClientHandshake<AllowStd<S>>>,
+    > + Unpin,
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let result = handshake(stream, f).await?;
@@ -111,11 +111,11 @@ pub(crate) async fn server_handshake<C, F, S>(
 where
     C: Callback + Unpin,
     F: FnOnce(
-            AllowStd<S>,
-        ) -> Result<
-            <ServerHandshake<AllowStd<S>, C> as HandshakeRole>::FinalResult,
-            Error<ServerHandshake<AllowStd<S>, C>>,
-        > + Unpin,
+        AllowStd<S>,
+    ) -> Result<
+        <ServerHandshake<AllowStd<S>, C> as HandshakeRole>::FinalResult,
+        Error<ServerHandshake<AllowStd<S>, C>>,
+    > + Unpin,
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let s: WebSocket<AllowStd<S>> = handshake(stream, f).await?;


### PR DESCRIPTION
Tokio 1.0 has just been [released](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.0.0) and PR updates to the latest release.

This depends on:
- [x] https://github.com/snapview/tungstenite-rs/pull/163 to be merged first which upgrades `tungstenite` to use bytes to 1.0.
- [x] https://github.com/tokio-rs/tls to be released first which upgrades `tokio-native-tls` to use tokio 1.0.

I will update this PR as the dependencies become ready.

Currently waiting on new release of the following crates to mark this PR as ready:
- [x] [input_buffer](https://github.com/snapview/input_buffer)
- [x] [tungstenite](https://github.com/snapview/tungstenite-rs)