### PR TITLE
Upgrade to tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ stream = []
 log = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
 pin-project = "1.0"
-tokio = { version = "0.3", default-features = false, features = ["io-util"] }
+tokio = { version = "1.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
 version = "0.11.1"
@@ -33,10 +33,10 @@ version = "0.2.0"
 
 [dependencies.tokio-native-tls]
 optional = true
-version = "0.2"
+version = "0.3"
 
 [dev-dependencies]
 futures-channel = "0.3"
-tokio = { version = "0.3", default-features = false, features = ["io-std", "macros", "rt-multi-thread", "stream", "time"] }
+tokio = { version = "1.0", default-features = false, features = ["io-std", "macros", "rt-multi-thread", "time"] }
 url = "2.0.0"
 env_logger = "0.7"

--- a/examples/interval-server.rs
+++ b/examples/interval-server.rs
@@ -1,7 +1,4 @@
-use futures_util::{
-    future::{select, Either},
-    SinkExt, StreamExt,
-};
+use futures_util::{SinkExt, StreamExt};
 use log::*;
 use std::{net::SocketAddr, time::Duration};
 use tokio::net::{TcpListener, TcpStream};
@@ -24,12 +21,9 @@ async fn handle_connection(peer: SocketAddr, stream: TcpStream) -> Result<()> {
     let mut interval = tokio::time::interval(Duration::from_millis(1000));
 
     // Echo incoming WebSocket messages and send a message periodically every second.
-
-    let mut msg_fut = ws_receiver.next();
-    let mut tick_fut = interval.next();
     loop {
-        match select(msg_fut, tick_fut).await {
-            Either::Left((msg, tick_fut_continue)) => {
+        tokio::select! {
+            msg = ws_receiver.next() => {
                 match msg {
                     Some(msg) => {
                         let msg = msg?;
@@ -38,16 +32,12 @@ async fn handle_connection(peer: SocketAddr, stream: TcpStream) -> Result<()> {
                         } else if msg.is_close() {
                             break;
                         }
-                        tick_fut = tick_fut_continue; // Continue waiting for tick.
-                        msg_fut = ws_receiver.next(); // Receive next WebSocket message.
                     }
                     None => break, // WebSocket stream terminated.
-                };
+                }
             }
-            Either::Right((_, msg_fut_continue)) => {
+            _ = interval.tick() => {
                 ws_sender.send(Message::Text("tick".to_owned())).await?;
-                msg_fut = msg_fut_continue; // Continue receiving the WebSocket message.
-                tick_fut = interval.next(); // Wait for next tick.
             }
         }
     }


### PR DESCRIPTION
The interval server example needed updating, since `tokio::time::Interval` is no longer a stream; both the `.next()` and the `.tick()` futures are stateless, so it's okay to "create" them in each loop iteration.
