### PR TITLE
Add support for rustls as TLS backend, update tungstenite version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,13 @@ jobs:
         run: cargo check
 
       - name: Check native-tls
-        run: cargo check --features use-native-tls
+        run: cargo check --features native-tls
 
       - name: Check rustls
-        run: cargo check --features use-rustls
+        run: cargo check --features rustls-tls
 
       - name: Check native-tls and rustls
-        run: cargo check --features use-native-tls,use-rustls
+        run: cargo check --features native-tls,rustls-tls
 
       - name: Test
         run: cargo test --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,14 @@ jobs:
       - name: Check default-features
         run: cargo check
 
-      - name: Check tls
-        run: cargo check --features tls
+      - name: Check native-tls
+        run: cargo check --features use-native-tls
+
+      - name: Check rustls
+        run: cargo check --features use-rustls
+
+      - name: Check native-tls and rustls
+        run: cargo check --features use-native-tls,use-rustls
 
       - name: Test
         run: cargo test --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.14.0
+
+- Support for `rustls` as TLS backend.
+  - The `tls` feature was renamed to `native-tls` and uses a OS-native TLS implementation.
+  - A new `native-tls-vendored` feature that uses `native-tls` but forces to build a vendored
+    version (mostly for `openssl`) instead of linking against the system installation.
+  - New `rustls-tls` feature flag to enable TLS with `rustls` as backend.
+  - `stream::Stream` was renamed to `MaybeTlsStream` and wraps a `rustls` TLS stream as well now.
+  - If both `native-tls` and `rustls-tls` are enabled `native-tls` is used by default.
+  - A new `Connector` was introduced that is similar to the previous `TlsConnector` but now allows
+    to control the used TLS backend explicitly (or disable it) in `client_async_tls_with_config`.
+
 # 0.13.0
 
 - Upgrade from Tokio 0.3 to Tokio 1.0.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ stream = []
 log = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
 pin-project = "1.0"
-tokio = { version = "1.2.0", default-features = false, features = ["io-util"] }
+tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
 version = "0.13.0"
@@ -56,9 +56,9 @@ version = "0.21.0"
 
 [dev-dependencies]
 futures-channel = "0.3"
-tokio = { version = "1.2.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
-url = "2.2.0"
-env_logger = "0.8.2"
+tokio = { version = "1.0.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
+url = "2.0.0"
+env_logger = "0.7"
 
 [[example]]
 name = "autobahn-client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ pin-project = "1.0"
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
-version = "0.12.0"
+version = "0.13.0"
 default-features = false
 git = "https://github.com/dnaka91/tungstenite-rs"
 branch = "rustls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ stream = []
 log = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
 pin-project = "1.0"
-tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
+tokio = { version = "1.2.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
 version = "0.13.0"
@@ -32,7 +32,7 @@ default-features = false
 [dependencies.native-tls-crate]
 optional = true
 package = "native-tls"
-version = "0.2.0"
+version = "0.2.7"
 
 [dependencies.rustls]
 optional = true
@@ -57,8 +57,8 @@ version = "0.21.0"
 [dev-dependencies]
 futures-channel = "0.3"
 tokio = { version = "1.2.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
-url = "2.0.0"
-env_logger = "0.7"
+url = "2.2.0"
+env_logger = "0.8.2"
 
 [[example]]
 name = "autobahn-client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ edition = "2018"
 [features]
 default = ["connect"]
 connect = ["stream", "tokio/net"]
-tls = ["native-tls", "tokio-native-tls", "stream", "tungstenite/tls"]
+use-native-tls = ["native-tls", "tokio-native-tls", "stream", "tungstenite/use-native-tls"]
+use-native-tls-vendored = ["use-native-tls", "native-tls/vendored", "tungstenite/use-native-tls-vendored"]
+use-rustls = ["rustls", "tokio-rustls", "stream", "tungstenite/use-rustls", "webpki", "webpki-roots"]
 stream = []
 
 [dependencies]
@@ -26,14 +28,32 @@ tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 [dependencies.tungstenite]
 version = "0.12.0"
 default-features = false
+git = "https://github.com/dnaka91/tungstenite-rs"
+branch = "rustls"
 
 [dependencies.native-tls]
 optional = true
 version = "0.2.0"
 
+[dependencies.rustls]
+optional = true
+version = "0.19.0"
+
 [dependencies.tokio-native-tls]
 optional = true
 version = "0.3.0"
+
+[dependencies.tokio-rustls]
+optional = true
+version = "0.22.0"
+
+[dependencies.webpki]
+optional = true
+version = "0.21.4"
+
+[dependencies.webpki-roots]
+optional = true
+version = "0.21.0"
 
 [dev-dependencies]
 futures-channel = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,6 @@ tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 [dependencies.tungstenite]
 version = "0.13.0"
 default-features = false
-git = "https://github.com/snapview/tungstenite-rs.git"
-branch = "master"
 
 [dependencies.native-tls-crate]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2018"
 [features]
 default = ["connect"]
 connect = ["stream", "tokio/net"]
-use-native-tls = ["native-tls", "tokio-native-tls", "stream", "tungstenite/use-native-tls"]
-use-native-tls-vendored = ["use-native-tls", "native-tls/vendored", "tungstenite/use-native-tls-vendored"]
-use-rustls = ["rustls", "tokio-rustls", "stream", "tungstenite/use-rustls", "webpki", "webpki-roots"]
+native-tls = ["native-tls-crate", "tokio-native-tls", "stream", "tungstenite/native-tls"]
+native-tls-vendored = ["native-tls", "native-tls-crate/vendored", "tungstenite/native-tls-vendored"]
+rustls-tls = ["rustls", "tokio-rustls", "stream", "tungstenite/rustls-tls", "webpki", "webpki-roots"]
 stream = []
 
 [dependencies]
@@ -28,11 +28,12 @@ tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 [dependencies.tungstenite]
 version = "0.13.0"
 default-features = false
-git = "https://github.com/dnaka91/tungstenite-rs"
+git = "https://github.com/dnaka91/tungstenite-rs.git"
 branch = "rustls"
 
-[dependencies.native-tls]
+[dependencies.native-tls-crate]
 optional = true
+package = "native-tls"
 version = "0.2.0"
 
 [dependencies.rustls]
@@ -57,6 +58,14 @@ version = "0.21.0"
 
 [dev-dependencies]
 futures-channel = "0.3"
-tokio = { version = "1.0.0", default-features = false, features = ["io-std", "macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.2.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
 url = "2.0.0"
 env_logger = "0.7"
+
+[[example]]
+name = "autobahn-client"
+required-features = ["connect"]
+
+[[example]]
+name = "client"
+required-features = ["connect"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 [dependencies.tungstenite]
 version = "0.13.0"
 default-features = false
-git = "https://github.com/dnaka91/tungstenite-rs.git"
-branch = "rustls"
+git = "https://github.com/snapview/tungstenite-rs.git"
+branch = "master"
 
 [dependencies.native-tls-crate]
 optional = true

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -108,11 +108,8 @@ pub(crate) mod encryption {
     }
 }
 
-#[cfg(feature = "native-tls")]
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 pub use self::encryption::MaybeTlsStream;
-#[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
-pub use self::encryption::MaybeTlsStream;
-
 pub use self::encryption::TlsConnector;
 
 #[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -13,136 +13,210 @@ use tungstenite::{
 
 use super::{client_async_with_config, IntoClientRequest, WebSocketStream};
 
-#[cfg(feature = "native-tls")]
 pub(crate) mod encryption {
-    use native_tls_crate::TlsConnector as NativeTlsConnector;
-    use tokio_native_tls::{TlsConnector as TokioTlsConnector, TlsStream};
-
-    use tokio::io::{AsyncRead, AsyncWrite};
-
-    use tungstenite::{error::TlsError, stream::Mode, Error};
-
-    use crate::stream::Stream as StreamSwitcher;
-
-    /// A stream that might be protected with TLS.
-    pub type MaybeTlsStream<S> = StreamSwitcher<S, TlsStream<S>>;
-
-    pub type AutoStream<S> = MaybeTlsStream<S>;
-
-    /// A TLS connector that can be used when establishing TLS connections.
-    pub type TlsConnector = NativeTlsConnector;
-
-    pub async fn wrap_stream<S>(
-        socket: S,
-        domain: String,
-        mode: Mode,
-        tls_connector: Option<TlsConnector>,
-    ) -> Result<AutoStream<S>, Error>
-    where
-        S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-    {
-        match mode {
-            Mode::Plain => Ok(StreamSwitcher::Plain(socket)),
-            Mode::Tls => {
-                let try_connector = tls_connector.map_or_else(TlsConnector::new, Ok);
-                let connector = try_connector.map_err(TlsError::Native)?;
-                let stream = TokioTlsConnector::from(connector);
-                let connected = stream.connect(&domain, socket).await;
-                match connected {
-                    Err(e) => Err(Error::Tls(e.into())),
-                    Ok(s) => Ok(StreamSwitcher::Tls(s)),
-                }
-            }
-        }
-    }
-}
-
-#[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
-pub(crate) mod encryption {
-    pub use rustls::ClientConfig;
-    use tokio_rustls::{webpki::DNSNameRef, TlsConnector as TokioTlsConnector, client::TlsStream};
-
-    use std::sync::Arc;
-    use tokio::io::{AsyncRead, AsyncWrite};
-
-    use tungstenite::{error::TlsError, stream::Mode, Error};
-
-    use crate::stream::Stream as StreamSwitcher;
-
-    /// A stream that might be protected with TLS.
-    pub type MaybeTlsStream<S> = StreamSwitcher<S, TlsStream<S>>;
-
-    pub type AutoStream<S> = MaybeTlsStream<S>;
-
-    /// A TLS connector that can be used when establishing TLS connections.
-    pub type TlsConnector = Arc<ClientConfig>;
-
-    pub async fn wrap_stream<S>(
-        socket: S,
-        domain: String,
-        mode: Mode,
-        tls_connector: Option<TlsConnector>,
-    ) -> Result<AutoStream<S>, Error>
-    where
-        S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-    {
-        match mode {
-            Mode::Plain => Ok(StreamSwitcher::Plain(socket)),
-            Mode::Tls => {
-                let config = tls_connector.unwrap_or_else(|| {
-                    let mut config = ClientConfig::new();
-                    config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-
-                    Arc::new(config)
-                });
-                let domain = DNSNameRef::try_from_ascii_str(&domain).map_err(TlsError::Dns)?;
-                let stream = TokioTlsConnector::from(config);
-                let connected = stream.connect(domain, socket).await;
-
-                match connected {
-                    Err(e) => Err(Error::Io(e)),
-                    Ok(s) => Ok(StreamSwitcher::Tls(s)),
-                }
-            }
-        }
-    }
-}
-
-#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-pub use self::encryption::MaybeTlsStream;
-pub use self::encryption::TlsConnector;
-
-#[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
-pub(crate) mod encryption {
-    use tokio::io::{AsyncRead, AsyncWrite};
-
-    use tungstenite::{
-        error::{Error, UrlError},
-        stream::Mode,
+    use std::{
+        marker::PhantomData,
+        pin::Pin,
+        task::{Context, Poll},
     };
 
-    pub type AutoStream<S> = S;
+    use pin_project::pin_project;
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+    use crate::stream::Stream;
+
+    /// A stream that might be protected with TLS.
+    pub type MaybeTlsStream<S> = Stream<S, TlsStream<S>>;
+
+    #[allow(missing_docs)]
+    #[non_exhaustive]
+    #[pin_project(project = StreamProj)]
+    pub enum TlsStream<S> {
+        Plain(PhantomData<S>),
+        #[cfg(feature = "native-tls")]
+        NativeTls(tokio_native_tls::TlsStream<S>),
+        #[cfg(feature = "rustls-tls")]
+        Rustls(tokio_rustls::client::TlsStream<S>),
+    }
+
+    #[cfg_attr(not(any(feature = "native-tls", feature = "rustls-tls")), allow(unused_variables))]
+    impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for TlsStream<S> {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            match self.project() {
+                StreamProj::Plain(_) => Poll::Ready(Ok(())),
+                #[cfg(feature = "native-tls")]
+                StreamProj::NativeTls(s) => Pin::new(s).poll_read(cx, buf),
+                #[cfg(feature = "rustls-tls")]
+                StreamProj::Rustls(s) => Pin::new(s).poll_read(cx, buf),
+            }
+        }
+    }
+
+    #[cfg_attr(not(any(feature = "native-tls", feature = "rustls-tls")), allow(unused_variables))]
+    impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for TlsStream<S> {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, std::io::Error>> {
+            match self.project() {
+                StreamProj::Plain(_) => Poll::Ready(Ok(0)),
+                #[cfg(feature = "native-tls")]
+                StreamProj::NativeTls(s) => Pin::new(s).poll_write(cx, buf),
+                #[cfg(feature = "rustls-tls")]
+                StreamProj::Rustls(s) => Pin::new(s).poll_write(cx, buf),
+            }
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), std::io::Error>> {
+            match self.project() {
+                StreamProj::Plain(_) => Poll::Ready(Ok(())),
+                #[cfg(feature = "native-tls")]
+                StreamProj::NativeTls(s) => Pin::new(s).poll_flush(cx),
+                #[cfg(feature = "rustls-tls")]
+                StreamProj::Rustls(s) => Pin::new(s).poll_flush(cx),
+            }
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), std::io::Error>> {
+            match self.project() {
+                StreamProj::Plain(_) => Poll::Ready(Ok(())),
+                #[cfg(feature = "native-tls")]
+                StreamProj::NativeTls(s) => Pin::new(s).poll_shutdown(cx),
+                #[cfg(feature = "rustls-tls")]
+                StreamProj::Rustls(s) => Pin::new(s).poll_shutdown(cx),
+            }
+        }
+    }
 
     /// A TLS connector that can be used when establishing TLS connections.
-    pub type TlsConnector = ();
+    #[non_exhaustive]
+    pub enum TlsConnector {
+        /// Plain (non-TLS) connector.
+        Plain,
+        /// `native-tls` TLS connector.
+        #[cfg(feature = "native-tls")]
+        NativeTls(native_tls_crate::TlsConnector),
+        /// `rustls` TLS connector.
+        #[cfg(feature = "rustls-tls")]
+        Rustls(std::sync::Arc<rustls::ClientConfig>),
+    }
 
-    pub async fn wrap_stream<S>(
-        socket: S,
-        _domain: String,
-        mode: Mode,
-        _tls_connector: Option<TlsConnector>,
-    ) -> Result<AutoStream<S>, Error>
-    where
-        S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-    {
-        match mode {
-            Mode::Plain => Ok(socket),
-            Mode::Tls => Err(Error::Url(UrlError::TlsFeatureNotEnabled)),
+    #[cfg(feature = "native-tls")]
+    pub mod native_tls {
+        use native_tls_crate::TlsConnector;
+        use tokio_native_tls::TlsConnector as TokioTlsConnector;
+
+        use tokio::io::{AsyncRead, AsyncWrite};
+
+        use tungstenite::{error::TlsError, stream::Mode, Error};
+
+        use super::{MaybeTlsStream, TlsStream};
+        use crate::stream::Stream as StreamSwitcher;
+
+        pub async fn wrap_stream<S>(
+            socket: S,
+            domain: String,
+            mode: Mode,
+            tls_connector: Option<TlsConnector>,
+        ) -> Result<MaybeTlsStream<S>, Error>
+        where
+            S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
+        {
+            match mode {
+                Mode::Plain => Ok(StreamSwitcher::Plain(socket)),
+                Mode::Tls => {
+                    let try_connector = tls_connector.map_or_else(TlsConnector::new, Ok);
+                    let connector = try_connector.map_err(TlsError::Native)?;
+                    let stream = TokioTlsConnector::from(connector);
+                    let connected = stream.connect(&domain, socket).await;
+                    match connected {
+                        Err(e) => Err(Error::Tls(e.into())),
+                        Ok(s) => Ok(StreamSwitcher::Tls(TlsStream::NativeTls(s))),
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "rustls-tls")]
+    pub mod rustls {
+        pub use rustls::ClientConfig;
+        use tokio_rustls::{webpki::DNSNameRef, TlsConnector as TokioTlsConnector};
+
+        use std::sync::Arc;
+        use tokio::io::{AsyncRead, AsyncWrite};
+
+        use tungstenite::{error::TlsError, stream::Mode, Error};
+
+        use super::{MaybeTlsStream, TlsStream};
+        use crate::stream::Stream as StreamSwitcher;
+
+        pub async fn wrap_stream<S>(
+            socket: S,
+            domain: String,
+            mode: Mode,
+            tls_connector: Option<Arc<ClientConfig>>,
+        ) -> Result<MaybeTlsStream<S>, Error>
+        where
+            S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
+        {
+            match mode {
+                Mode::Plain => Ok(StreamSwitcher::Plain(socket)),
+                Mode::Tls => {
+                    let config = tls_connector.unwrap_or_else(|| {
+                        let mut config = ClientConfig::new();
+                        config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+
+                        Arc::new(config)
+                    });
+                    let domain = DNSNameRef::try_from_ascii_str(&domain).map_err(TlsError::Dns)?;
+                    let stream = TokioTlsConnector::from(config);
+                    let connected = stream.connect(domain, socket).await;
+
+                    match connected {
+                        Err(e) => Err(Error::Io(e)),
+                        Ok(s) => Ok(StreamSwitcher::Tls(TlsStream::Rustls(s))),
+                    }
+                }
+            }
+        }
+    }
+
+    pub mod plain {
+        use tokio::io::{AsyncRead, AsyncWrite};
+
+        use tungstenite::{
+            error::{Error, UrlError},
+            stream::Mode,
+        };
+
+        use super::MaybeTlsStream;
+        use crate::stream::Stream as StreamSwitcher;
+
+        pub async fn wrap_stream<S>(socket: S, mode: Mode) -> Result<MaybeTlsStream<S>, Error>
+        where
+            S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
+        {
+            match mode {
+                Mode::Plain => Ok(StreamSwitcher::Plain(socket)),
+                Mode::Tls => Err(Error::Url(UrlError::TlsFeatureNotEnabled)),
+            }
         }
     }
 }
 
-use self::encryption::{wrap_stream, AutoStream};
+pub use self::encryption::{MaybeTlsStream, TlsConnector, TlsStream};
 
 /// Get a domain from an URL.
 #[inline]
@@ -158,11 +232,11 @@ fn domain(request: &Request) -> Result<String, Error> {
 pub async fn client_async_tls<R, S>(
     request: R,
     stream: S,
-) -> Result<(WebSocketStream<AutoStream<S>>, Response), Error>
+) -> Result<(WebSocketStream<MaybeTlsStream<S>>, Response), Error>
 where
     R: IntoClientRequest + Unpin,
     S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-    AutoStream<S>: Unpin,
+    MaybeTlsStream<S>: Unpin,
 {
     client_async_tls_with_config(request, stream, None, None).await
 }
@@ -177,27 +251,55 @@ pub async fn client_async_tls_with_config<R, S>(
     stream: S,
     config: Option<WebSocketConfig>,
     tls_connector: Option<TlsConnector>,
-) -> Result<(WebSocketStream<AutoStream<S>>, Response), Error>
+) -> Result<(WebSocketStream<MaybeTlsStream<S>>, Response), Error>
 where
     R: IntoClientRequest + Unpin,
     S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-    AutoStream<S>: Unpin,
+    MaybeTlsStream<S>: Unpin,
 {
     let request = request.into_client_request()?;
 
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     let domain = domain(&request)?;
 
     // Make sure we check domain and mode first. URL must be valid.
     let mode = uri_mode(&request.uri())?;
 
-    let stream = wrap_stream(stream, domain, mode, tls_connector).await?;
+    let stream = match tls_connector {
+        Some(conn) => match conn {
+            #[cfg(feature = "native-tls")]
+            TlsConnector::NativeTls(conn) => {
+                self::encryption::native_tls::wrap_stream(stream, domain, mode, Some(conn)).await
+            }
+            #[cfg(feature = "rustls-tls")]
+            TlsConnector::Rustls(conn) => {
+                self::encryption::rustls::wrap_stream(stream, domain, mode, Some(conn)).await
+            }
+            TlsConnector::Plain => self::encryption::plain::wrap_stream(stream, mode).await,
+        },
+        None => {
+            #[cfg(feature = "native-tls")]
+            {
+                self::encryption::native_tls::wrap_stream(stream, domain, mode, None).await
+            }
+            #[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
+            {
+                self::encryption::rustls::wrap_stream(stream, domain, mode, None).await
+            }
+            #[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+            {
+                self::encryption::plain::wrap_stream(stream, mode).await
+            }
+        }
+    }?;
+
     client_async_with_config(request, stream, config).await
 }
 
 /// Connect to a given URL.
 pub async fn connect_async<R>(
     request: R,
-) -> Result<(WebSocketStream<AutoStream<TcpStream>>, Response), Error>
+) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), Error>
 where
     R: IntoClientRequest + Unpin,
 {
@@ -209,7 +311,7 @@ where
 pub async fn connect_async_with_config<R>(
     request: R,
     config: Option<WebSocketConfig>,
-) -> Result<(WebSocketStream<AutoStream<TcpStream>>, Response), Error>
+) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), Error>
 where
     R: IntoClientRequest + Unpin,
 {

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -60,7 +60,7 @@ pub(crate) mod encryption {
 #[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
 pub(crate) mod encryption {
     pub use rustls::ClientConfig;
-    use tokio_rustls::{webpki::DNSNameRef, TlsConnector as TokioTlsConnector, TlsStream};
+    use tokio_rustls::{webpki::DNSNameRef, TlsConnector as TokioTlsConnector, client::TlsStream};
 
     use std::sync::Arc;
     use tokio::io::{AsyncRead, AsyncWrite};
@@ -101,7 +101,7 @@ pub(crate) mod encryption {
 
                 match connected {
                     Err(e) => Err(Error::Io(e)),
-                    Ok(s) => Ok(StreamSwitcher::Tls(TlsStream::Client(s))),
+                    Ok(s) => Ok(StreamSwitcher::Tls(s)),
                 }
             }
         }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -45,16 +45,10 @@ pub(crate) mod encryption {
             Mode::Plain => Ok(StreamSwitcher::Plain(socket)),
             Mode::Tls => {
                 let try_connector = tls_connector.map_or_else(TlsConnector::new, Ok);
-                #[cfg(feature = "native-tls")]
                 let connector = try_connector.map_err(TlsError::Native)?;
-                #[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
-                let connector = try_connector.map_err(TlsError::Rustls)?;
                 let stream = TokioTlsConnector::from(connector);
                 let connected = stream.connect(&domain, socket).await;
                 match connected {
-                    #[cfg(feature = "native-tls")]
-                    Err(e) => Err(Error::Tls(e.into())),
-                    #[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
                     Err(e) => Err(Error::Tls(e.into())),
                     Ok(s) => Ok(StreamSwitcher::Tls(s)),
                 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,213 +1,13 @@
 //! Connection helper.
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    net::TcpStream,
-};
+use tokio::net::TcpStream;
 
 use tungstenite::{
-    client::uri_mode,
     error::{Error, UrlError},
-    handshake::client::{Request, Response},
+    handshake::client::Response,
     protocol::WebSocketConfig,
 };
 
-use super::{client_async_with_config, IntoClientRequest, WebSocketStream};
-
-pub(crate) mod encryption {
-    /// A TLS connector that can be used when establishing TLS connections.
-    #[non_exhaustive]
-    pub enum TlsConnector {
-        /// Plain (non-TLS) connector.
-        Plain,
-        /// `native-tls` TLS connector.
-        #[cfg(feature = "native-tls")]
-        NativeTls(native_tls_crate::TlsConnector),
-        /// `rustls` TLS connector.
-        #[cfg(feature = "rustls-tls")]
-        Rustls(std::sync::Arc<rustls::ClientConfig>),
-    }
-
-    #[cfg(feature = "native-tls")]
-    pub mod native_tls {
-        use native_tls_crate::TlsConnector;
-        use tokio_native_tls::TlsConnector as TokioTlsConnector;
-
-        use tokio::io::{AsyncRead, AsyncWrite};
-
-        use tungstenite::{error::TlsError, stream::Mode, Error};
-
-        use crate::stream::MaybeTlsStream;
-
-        pub async fn wrap_stream<S>(
-            socket: S,
-            domain: String,
-            mode: Mode,
-            tls_connector: Option<TlsConnector>,
-        ) -> Result<MaybeTlsStream<S>, Error>
-        where
-            S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-        {
-            match mode {
-                Mode::Plain => Ok(MaybeTlsStream::Plain(socket)),
-                Mode::Tls => {
-                    let try_connector = tls_connector.map_or_else(TlsConnector::new, Ok);
-                    let connector = try_connector.map_err(TlsError::Native)?;
-                    let stream = TokioTlsConnector::from(connector);
-                    let connected = stream.connect(&domain, socket).await;
-                    match connected {
-                        Err(e) => Err(Error::Tls(e.into())),
-                        Ok(s) => Ok(MaybeTlsStream::NativeTls(s)),
-                    }
-                }
-            }
-        }
-    }
-
-    #[cfg(feature = "rustls-tls")]
-    pub mod rustls {
-        pub use rustls::ClientConfig;
-        use tokio_rustls::{webpki::DNSNameRef, TlsConnector as TokioTlsConnector};
-
-        use std::sync::Arc;
-        use tokio::io::{AsyncRead, AsyncWrite};
-
-        use tungstenite::{error::TlsError, stream::Mode, Error};
-
-        use crate::stream::MaybeTlsStream;
-
-        pub async fn wrap_stream<S>(
-            socket: S,
-            domain: String,
-            mode: Mode,
-            tls_connector: Option<Arc<ClientConfig>>,
-        ) -> Result<MaybeTlsStream<S>, Error>
-        where
-            S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-        {
-            match mode {
-                Mode::Plain => Ok(MaybeTlsStream::Plain(socket)),
-                Mode::Tls => {
-                    let config = tls_connector.unwrap_or_else(|| {
-                        let mut config = ClientConfig::new();
-                        config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
-
-                        Arc::new(config)
-                    });
-                    let domain = DNSNameRef::try_from_ascii_str(&domain).map_err(TlsError::Dns)?;
-                    let stream = TokioTlsConnector::from(config);
-                    let connected = stream.connect(domain, socket).await;
-
-                    match connected {
-                        Err(e) => Err(Error::Io(e)),
-                        Ok(s) => Ok(MaybeTlsStream::Rustls(s)),
-                    }
-                }
-            }
-        }
-    }
-
-    pub mod plain {
-        use tokio::io::{AsyncRead, AsyncWrite};
-
-        use tungstenite::{
-            error::{Error, UrlError},
-            stream::Mode,
-        };
-
-        use crate::stream::MaybeTlsStream;
-
-        pub async fn wrap_stream<S>(socket: S, mode: Mode) -> Result<MaybeTlsStream<S>, Error>
-        where
-            S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-        {
-            match mode {
-                Mode::Plain => Ok(MaybeTlsStream::Plain(socket)),
-                Mode::Tls => Err(Error::Url(UrlError::TlsFeatureNotEnabled)),
-            }
-        }
-    }
-}
-
-pub use self::encryption::TlsConnector;
-pub use crate::stream::MaybeTlsStream;
-
-/// Get a domain from an URL.
-#[inline]
-fn domain(request: &Request) -> Result<String, Error> {
-    match request.uri().host() {
-        Some(d) => Ok(d.to_string()),
-        None => Err(Error::Url(UrlError::NoHostName)),
-    }
-}
-
-/// Creates a WebSocket handshake from a request and a stream,
-/// upgrading the stream to TLS if required.
-pub async fn client_async_tls<R, S>(
-    request: R,
-    stream: S,
-) -> Result<(WebSocketStream<MaybeTlsStream<S>>, Response), Error>
-where
-    R: IntoClientRequest + Unpin,
-    S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-    MaybeTlsStream<S>: Unpin,
-{
-    client_async_tls_with_config(request, stream, None, None).await
-}
-
-/// The same as `client_async_tls()` but the one can specify a websocket configuration,
-/// and an optional TLS connector. If no connector is specified, the default one will
-/// be created.
-///
-/// Please refer to `client_async_tls()` for more details.
-pub async fn client_async_tls_with_config<R, S>(
-    request: R,
-    stream: S,
-    config: Option<WebSocketConfig>,
-    tls_connector: Option<TlsConnector>,
-) -> Result<(WebSocketStream<MaybeTlsStream<S>>, Response), Error>
-where
-    R: IntoClientRequest + Unpin,
-    S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
-    MaybeTlsStream<S>: Unpin,
-{
-    let request = request.into_client_request()?;
-
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-    let domain = domain(&request)?;
-
-    // Make sure we check domain and mode first. URL must be valid.
-    let mode = uri_mode(&request.uri())?;
-
-    let stream = match tls_connector {
-        Some(conn) => match conn {
-            #[cfg(feature = "native-tls")]
-            TlsConnector::NativeTls(conn) => {
-                self::encryption::native_tls::wrap_stream(stream, domain, mode, Some(conn)).await
-            }
-            #[cfg(feature = "rustls-tls")]
-            TlsConnector::Rustls(conn) => {
-                self::encryption::rustls::wrap_stream(stream, domain, mode, Some(conn)).await
-            }
-            TlsConnector::Plain => self::encryption::plain::wrap_stream(stream, mode).await,
-        },
-        None => {
-            #[cfg(feature = "native-tls")]
-            {
-                self::encryption::native_tls::wrap_stream(stream, domain, mode, None).await
-            }
-            #[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
-            {
-                self::encryption::rustls::wrap_stream(stream, domain, mode, None).await
-            }
-            #[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
-            {
-                self::encryption::plain::wrap_stream(stream, mode).await
-            }
-        }
-    }?;
-
-    client_async_with_config(request, stream, config).await
-}
+use crate::{domain, stream::MaybeTlsStream, IntoClientRequest, WebSocketStream};
 
 /// Connect to a given URL.
 pub async fn connect_async<R>(
@@ -244,5 +44,14 @@ where
     let addr = format!("{}:{}", domain, port);
     let try_socket = TcpStream::connect(addr).await;
     let socket = try_socket.map_err(Error::Io)?;
-    client_async_tls_with_config(request, socket, config, None).await
+
+    #[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+    {
+        crate::client_async_with_config(request, MaybeTlsStream::Plain(socket), config).await
+    }
+
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    {
+        crate::tls::client_async_tls_with_config(request, socket, config, None).await
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,9 +55,6 @@ pub use connect::{
 pub use connect::MaybeTlsStream;
 use tungstenite::protocol::CloseFrame;
 
-#[cfg(all(feature = "use-native-tls", feature = "use-rustls"))]
-compile_error!("either \"use-native-tls\" or \"use-rustls\" can be enabled, but not both.");
-
 /// Creates a WebSocket handshake from a request and a stream.
 /// For convenience, the user may call this with a url string, a URL,
 /// or a `Request`. Calling with `Request` allows the user to add

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ use tungstenite::{
 #[cfg(feature = "connect")]
 pub use connect::{
     client_async_tls, client_async_tls_with_config, connect_async, connect_async_with_config,
-    MaybeTlsStream, TlsConnector, TlsStream,
+    MaybeTlsStream, TlsConnector,
 };
 
 use tungstenite::protocol::CloseFrame;
@@ -318,7 +318,7 @@ where
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "connect")]
-    use crate::connect::encryption::MaybeTlsStream;
+    use crate::stream::MaybeTlsStream;
     use crate::{compat::AllowStd, WebSocketStream};
     use std::io::{Read, Write};
     #[cfg(feature = "connect")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,12 @@ pub use connect::{
     TlsConnector,
 };
 
-#[cfg(all(feature = "connect", feature = "tls"))]
+#[cfg(all(feature = "connect", any(feature = "use-native-tls", feature = "use-rustls")))]
 pub use connect::MaybeTlsStream;
 use tungstenite::protocol::CloseFrame;
+
+#[cfg(all(feature = "use-native-tls", feature = "use-rustls"))]
+compile_error!("either \"use-native-tls\" or \"use-rustls\" can be enabled, but not both.");
 
 /// Creates a WebSocket handshake from a request and a stream.
 /// For convenience, the user may call this with a url string, a URL,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ use tungstenite::{
 };
 
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-pub use tls::{client_async_tls, client_async_tls_with_config, TlsConnector};
+pub use tls::{client_async_tls, client_async_tls_with_config, Connector};
 
 #[cfg(feature = "connect")]
 pub use connect::{connect_async, connect_async_with_config};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub use connect::{
     TlsConnector,
 };
 
-#[cfg(all(feature = "connect", any(feature = "use-native-tls", feature = "use-rustls")))]
+#[cfg(all(feature = "connect", any(feature = "native-tls", feature = "rustls-tls")))]
 pub use connect::MaybeTlsStream;
 use tungstenite::protocol::CloseFrame;
 
@@ -323,11 +323,14 @@ mod tests {
     use crate::connect::encryption::AutoStream;
     use crate::{compat::AllowStd, WebSocketStream};
     use std::io::{Read, Write};
+    #[cfg(feature = "connect")]
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     fn is_read<T: Read>() {}
     fn is_write<T: Write>() {}
+    #[cfg(feature = "connect")]
     fn is_async_read<T: AsyncReadExt>() {}
+    #[cfg(feature = "connect")]
     fn is_async_write<T: AsyncWriteExt>() {}
     fn is_unpin<T: Unpin>() {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,9 @@ use tungstenite::{
 #[cfg(feature = "connect")]
 pub use connect::{
     client_async_tls, client_async_tls_with_config, connect_async, connect_async_with_config,
-    TlsConnector,
+    MaybeTlsStream, TlsConnector, TlsStream,
 };
 
-#[cfg(all(feature = "connect", any(feature = "native-tls", feature = "rustls-tls")))]
-pub use connect::MaybeTlsStream;
 use tungstenite::protocol::CloseFrame;
 
 /// Creates a WebSocket handshake from a request and a stream.
@@ -320,7 +318,7 @@ where
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "connect")]
-    use crate::connect::encryption::AutoStream;
+    use crate::connect::encryption::MaybeTlsStream;
     use crate::{compat::AllowStd, WebSocketStream};
     use std::io::{Read, Write};
     #[cfg(feature = "connect")]
@@ -340,12 +338,12 @@ mod tests {
         is_write::<AllowStd<tokio::net::TcpStream>>();
 
         #[cfg(feature = "connect")]
-        is_async_read::<AutoStream<tokio::net::TcpStream>>();
+        is_async_read::<MaybeTlsStream<tokio::net::TcpStream>>();
         #[cfg(feature = "connect")]
-        is_async_write::<AutoStream<tokio::net::TcpStream>>();
+        is_async_write::<MaybeTlsStream<tokio::net::TcpStream>>();
 
         is_unpin::<WebSocketStream<tokio::net::TcpStream>>();
         #[cfg(feature = "connect")]
-        is_unpin::<WebSocketStream<AutoStream<tokio::net::TcpStream>>>();
+        is_unpin::<WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>>();
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -17,10 +17,10 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 pub enum MaybeTlsStream<S> {
     /// Unencrypted socket stream.
     Plain(#[pin] S),
-    /// Encrypted socket stream using [`native-tls`].
+    /// Encrypted socket stream using `native-tls`.
     #[cfg(feature = "native-tls")]
     NativeTls(tokio_native_tls::TlsStream<S>),
-    /// Encrypted socket stream using [`rustls`].
+    /// Encrypted socket stream using `rustls`.
     #[cfg(feature = "rustls-tls")]
     Rustls(tokio_rustls::client::TlsStream<S>),
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -11,16 +11,20 @@ use std::{
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-/// Stream, either plain TCP or TLS.
+/// A stream that might be protected with TLS.
 #[pin_project(project = StreamProj)]
-pub enum Stream<S, T> {
+pub enum MaybeTlsStream<S> {
     /// Unencrypted socket stream.
     Plain(#[pin] S),
-    /// Encrypted socket stream.
-    Tls(#[pin] T),
+    /// Encrypted socket stream using [`native-tls`].
+    #[cfg(feature = "native-tls")]
+    NativeTls(tokio_native_tls::TlsStream<S>),
+    /// Encrypted socket stream using [`rustls`].
+    #[cfg(feature = "rustls-tls")]
+    Rustls(tokio_rustls::client::TlsStream<S>),
 }
 
-impl<S: AsyncRead + Unpin, T: AsyncRead + Unpin> AsyncRead for Stream<S, T> {
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncRead for MaybeTlsStream<S> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -28,12 +32,15 @@ impl<S: AsyncRead + Unpin, T: AsyncRead + Unpin> AsyncRead for Stream<S, T> {
     ) -> Poll<std::io::Result<()>> {
         match self.project() {
             StreamProj::Plain(ref mut s) => Pin::new(s).poll_read(cx, buf),
-            StreamProj::Tls(ref mut s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(feature = "native-tls")]
+            StreamProj::NativeTls(s) => Pin::new(s).poll_read(cx, buf),
+            #[cfg(feature = "rustls-tls")]
+            StreamProj::Rustls(s) => Pin::new(s).poll_read(cx, buf),
         }
     }
 }
 
-impl<S: AsyncWrite + Unpin, T: AsyncWrite + Unpin> AsyncWrite for Stream<S, T> {
+impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for MaybeTlsStream<S> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -41,14 +48,20 @@ impl<S: AsyncWrite + Unpin, T: AsyncWrite + Unpin> AsyncWrite for Stream<S, T> {
     ) -> Poll<Result<usize, std::io::Error>> {
         match self.project() {
             StreamProj::Plain(ref mut s) => Pin::new(s).poll_write(cx, buf),
-            StreamProj::Tls(ref mut s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "native-tls")]
+            StreamProj::NativeTls(s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "rustls-tls")]
+            StreamProj::Rustls(s) => Pin::new(s).poll_write(cx, buf),
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
         match self.project() {
             StreamProj::Plain(ref mut s) => Pin::new(s).poll_flush(cx),
-            StreamProj::Tls(ref mut s) => Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "native-tls")]
+            StreamProj::NativeTls(s) => Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "rustls-tls")]
+            StreamProj::Rustls(s) => Pin::new(s).poll_flush(cx),
         }
     }
 
@@ -58,7 +71,10 @@ impl<S: AsyncWrite + Unpin, T: AsyncWrite + Unpin> AsyncWrite for Stream<S, T> {
     ) -> Poll<Result<(), std::io::Error>> {
         match self.project() {
             StreamProj::Plain(ref mut s) => Pin::new(s).poll_shutdown(cx),
-            StreamProj::Tls(ref mut s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(feature = "native-tls")]
+            StreamProj::NativeTls(s) => Pin::new(s).poll_shutdown(cx),
+            #[cfg(feature = "rustls-tls")]
+            StreamProj::Rustls(s) => Pin::new(s).poll_shutdown(cx),
         }
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -12,6 +12,7 @@ use std::{
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 /// A stream that might be protected with TLS.
+#[non_exhaustive]
 #[pin_project(project = StreamProj)]
 pub enum MaybeTlsStream<S> {
     /// Unencrypted socket stream.

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -9,7 +9,9 @@ use crate::{client_async_with_config, domain, IntoClientRequest, WebSocketStream
 
 pub use crate::stream::MaybeTlsStream;
 
-/// A connector that can be used when establishing TLS connections.
+/// A connector that can be used when establishing connections, allowing to control whether
+/// `native-tls` or `rustls` is used to create a TLS connection. Or TLS can be disabled with the
+/// `Plain` variant.
 #[non_exhaustive]
 pub enum Connector {
     /// Plain (non-TLS) connector.
@@ -139,7 +141,7 @@ where
 }
 
 /// The same as `client_async_tls()` but the one can specify a websocket configuration,
-/// and an optional TLS connector. If no connector is specified, the default one will
+/// and an optional connector. If no connector is specified, a default one will
 /// be created.
 ///
 /// Please refer to `client_async_tls()` for more details.

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,194 @@
+//! Connection helper.
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use tungstenite::{
+    client::uri_mode, error::Error, handshake::client::Response, protocol::WebSocketConfig,
+};
+
+use crate::{client_async_with_config, domain, IntoClientRequest, WebSocketStream};
+
+pub use crate::stream::MaybeTlsStream;
+
+/// A TLS connector that can be used when establishing TLS connections.
+#[non_exhaustive]
+pub enum TlsConnector {
+    /// Plain (non-TLS) connector.
+    Plain,
+    /// `native-tls` TLS connector.
+    #[cfg(feature = "native-tls")]
+    NativeTls(native_tls_crate::TlsConnector),
+    /// `rustls` TLS connector.
+    #[cfg(feature = "rustls-tls")]
+    Rustls(std::sync::Arc<rustls::ClientConfig>),
+}
+
+mod encryption {
+    #[cfg(feature = "native-tls")]
+    pub mod native_tls {
+        use native_tls_crate::TlsConnector;
+        use tokio_native_tls::TlsConnector as TokioTlsConnector;
+
+        use tokio::io::{AsyncRead, AsyncWrite};
+
+        use tungstenite::{error::TlsError, stream::Mode, Error};
+
+        use crate::stream::MaybeTlsStream;
+
+        pub async fn wrap_stream<S>(
+            socket: S,
+            domain: String,
+            mode: Mode,
+            tls_connector: Option<TlsConnector>,
+        ) -> Result<MaybeTlsStream<S>, Error>
+        where
+            S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
+        {
+            match mode {
+                Mode::Plain => Ok(MaybeTlsStream::Plain(socket)),
+                Mode::Tls => {
+                    let try_connector = tls_connector.map_or_else(TlsConnector::new, Ok);
+                    let connector = try_connector.map_err(TlsError::Native)?;
+                    let stream = TokioTlsConnector::from(connector);
+                    let connected = stream.connect(&domain, socket).await;
+                    match connected {
+                        Err(e) => Err(Error::Tls(e.into())),
+                        Ok(s) => Ok(MaybeTlsStream::NativeTls(s)),
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "rustls-tls")]
+    pub mod rustls {
+        pub use rustls::ClientConfig;
+        use tokio_rustls::{webpki::DNSNameRef, TlsConnector as TokioTlsConnector};
+
+        use std::sync::Arc;
+        use tokio::io::{AsyncRead, AsyncWrite};
+
+        use tungstenite::{error::TlsError, stream::Mode, Error};
+
+        use crate::stream::MaybeTlsStream;
+
+        pub async fn wrap_stream<S>(
+            socket: S,
+            domain: String,
+            mode: Mode,
+            tls_connector: Option<Arc<ClientConfig>>,
+        ) -> Result<MaybeTlsStream<S>, Error>
+        where
+            S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
+        {
+            match mode {
+                Mode::Plain => Ok(MaybeTlsStream::Plain(socket)),
+                Mode::Tls => {
+                    let config = tls_connector.unwrap_or_else(|| {
+                        let mut config = ClientConfig::new();
+                        config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+
+                        Arc::new(config)
+                    });
+                    let domain = DNSNameRef::try_from_ascii_str(&domain).map_err(TlsError::Dns)?;
+                    let stream = TokioTlsConnector::from(config);
+                    let connected = stream.connect(domain, socket).await;
+
+                    match connected {
+                        Err(e) => Err(Error::Io(e)),
+                        Ok(s) => Ok(MaybeTlsStream::Rustls(s)),
+                    }
+                }
+            }
+        }
+    }
+
+    pub mod plain {
+        use tokio::io::{AsyncRead, AsyncWrite};
+
+        use tungstenite::{
+            error::{Error, UrlError},
+            stream::Mode,
+        };
+
+        use crate::stream::MaybeTlsStream;
+
+        pub async fn wrap_stream<S>(socket: S, mode: Mode) -> Result<MaybeTlsStream<S>, Error>
+        where
+            S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
+        {
+            match mode {
+                Mode::Plain => Ok(MaybeTlsStream::Plain(socket)),
+                Mode::Tls => Err(Error::Url(UrlError::TlsFeatureNotEnabled)),
+            }
+        }
+    }
+}
+
+/// Creates a WebSocket handshake from a request and a stream,
+/// upgrading the stream to TLS if required.
+pub async fn client_async_tls<R, S>(
+    request: R,
+    stream: S,
+) -> Result<(WebSocketStream<MaybeTlsStream<S>>, Response), Error>
+where
+    R: IntoClientRequest + Unpin,
+    S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
+    MaybeTlsStream<S>: Unpin,
+{
+    client_async_tls_with_config(request, stream, None, None).await
+}
+
+/// The same as `client_async_tls()` but the one can specify a websocket configuration,
+/// and an optional TLS connector. If no connector is specified, the default one will
+/// be created.
+///
+/// Please refer to `client_async_tls()` for more details.
+pub async fn client_async_tls_with_config<R, S>(
+    request: R,
+    stream: S,
+    config: Option<WebSocketConfig>,
+    tls_connector: Option<TlsConnector>,
+) -> Result<(WebSocketStream<MaybeTlsStream<S>>, Response), Error>
+where
+    R: IntoClientRequest + Unpin,
+    S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
+    MaybeTlsStream<S>: Unpin,
+{
+    let request = request.into_client_request()?;
+
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    let domain = domain(&request)?;
+
+    // Make sure we check domain and mode first. URL must be valid.
+    let mode = uri_mode(&request.uri())?;
+
+    let stream = match tls_connector {
+        Some(conn) => match conn {
+            #[cfg(feature = "native-tls")]
+            TlsConnector::NativeTls(conn) => {
+                self::encryption::native_tls::wrap_stream(stream, domain, mode, Some(conn)).await
+            }
+            #[cfg(feature = "rustls-tls")]
+            TlsConnector::Rustls(conn) => {
+                self::encryption::rustls::wrap_stream(stream, domain, mode, Some(conn)).await
+            }
+            TlsConnector::Plain => self::encryption::plain::wrap_stream(stream, mode).await,
+        },
+        None => {
+            #[cfg(feature = "native-tls")]
+            {
+                self::encryption::native_tls::wrap_stream(stream, domain, mode, None).await
+            }
+            #[cfg(all(feature = "rustls-tls", not(feature = "native-tls")))]
+            {
+                self::encryption::rustls::wrap_stream(stream, domain, mode, None).await
+            }
+            #[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+            {
+                self::encryption::plain::wrap_stream(stream, mode).await
+            }
+        }
+    }?;
+
+    client_async_with_config(request, stream, config).await
+}


### PR DESCRIPTION
This adds support for `rustls` as TLS backend. It depends on `tungstenite-rs` 0.13.

Naming is exactly the same as in tungstenite and I added a missing feature for vendoring as well as it only existed in tungstenite so far: `native-tls-vendored`.

Fixes #127.