### PR TITLE
depend on tokio 1.0 instead of 1.0.0; fixes #148

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,6 @@ version = "0.3.0"
 
 [dev-dependencies]
 futures-channel = "0.3"
-tokio = { version = "1.0.0", default-features = false, features = ["io-std", "macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.0", default-features = false, features = ["io-std", "macros", "rt-multi-thread", "time"] }
 url = "2.0.0"
 env_logger = "0.7"


### PR DESCRIPTION
Change `Cargo.toml` to depend on tokio 1.0

fixes #148