### PR TITLE
Upgrade tungstenite from 0.12 to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [features]
 default = ["connect"]
 connect = ["stream", "tokio/net"]
-tls = ["native-tls", "tokio-native-tls", "stream", "tungstenite/tls"]
+tls = ["native-tls", "tokio-native-tls", "stream", "tungstenite/native-tls"]
 stream = []
 
 [dependencies]
@@ -24,7 +24,7 @@ pin-project = "1.0"
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
-version = "0.12.0"
+version = "0.13.0"
 default-features = false
 
 [dependencies.native-tls]


### PR DESCRIPTION
Tungstenite now supports "native-tls" and "rustls-tls". For backwards compatibility I'm using "native-tls". We could also expose "rustls-tls", but I didn't do it yet.

wdyt?


[Changelog](https://github.com/snapview/tungstenite-rs/blob/master/CHANGELOG.md)

# 0.13.0
- Add `CapacityError`, `UrlError`, and `ProtocolError` types to represent the different types of capacity, URL, and protocol errors respectively.
- Modify variants `Error::Capacity`, `Error::Url`, and `Error::Protocol` to hold the above errors types instead of string error messages.
- Add `handshake::derive_accept_key` to facilitate external handshakes.
- Add support for `rustls` as TLS backend. The previous `tls` feature flag is now removed in favor
  of `native-tls` and `rustls-tls`, which allows to pick the TLS backend. The error API surface had
  to be changed to support the new error types coming from rustls related crates.