### PR TITLE
Use 127.0.0.1 in tests to avoid firewall warnings

### DIFF
--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -92,11 +92,11 @@ pub(crate) async fn client_handshake<F, S>(
 ) -> Result<(WebSocketStream<S>, Response), Error<ClientHandshake<AllowStd<S>>>>
 where
     F: FnOnce(
-        AllowStd<S>,
-    ) -> Result<
-        <ClientHandshake<AllowStd<S>> as HandshakeRole>::FinalResult,
-        Error<ClientHandshake<AllowStd<S>>>,
-    > + Unpin,
+            AllowStd<S>,
+        ) -> Result<
+            <ClientHandshake<AllowStd<S>> as HandshakeRole>::FinalResult,
+            Error<ClientHandshake<AllowStd<S>>>,
+        > + Unpin,
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let result = handshake(stream, f).await?;
@@ -111,11 +111,11 @@ pub(crate) async fn server_handshake<C, F, S>(
 where
     C: Callback + Unpin,
     F: FnOnce(
-        AllowStd<S>,
-    ) -> Result<
-        <ServerHandshake<AllowStd<S>, C> as HandshakeRole>::FinalResult,
-        Error<ServerHandshake<AllowStd<S>, C>>,
-    > + Unpin,
+            AllowStd<S>,
+        ) -> Result<
+            <ServerHandshake<AllowStd<S>, C> as HandshakeRole>::FinalResult,
+            Error<ServerHandshake<AllowStd<S>, C>>,
+        > + Unpin,
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let s: WebSocket<AllowStd<S>> = handshake(stream, f).await?;

--- a/tests/communication.rs
+++ b/tests/communication.rs
@@ -32,7 +32,7 @@ async fn communication() {
     let (msg_tx, msg_rx) = futures_channel::oneshot::channel();
 
     let f = async move {
-        let listener = TcpListener::bind("0.0.0.0:12345").await.unwrap();
+        let listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
         info!("Server ready");
         con_tx.send(()).unwrap();
         info!("Waiting on next connection");
@@ -47,7 +47,7 @@ async fn communication() {
     info!("Waiting for server to be ready");
 
     con_rx.await.expect("Server not ready");
-    let tcp = TcpStream::connect("0.0.0.0:12345").await.expect("Failed to connect");
+    let tcp = TcpStream::connect("127.0.0.1:12345").await.expect("Failed to connect");
     let url = "ws://localhost:12345/";
     let (mut stream, _) = client_async(url, tcp).await.expect("Client failed to connect");
 
@@ -71,7 +71,7 @@ async fn split_communication() {
     let (msg_tx, msg_rx) = futures_channel::oneshot::channel();
 
     let f = async move {
-        let listener = TcpListener::bind("0.0.0.0:12346").await.unwrap();
+        let listener = TcpListener::bind("127.0.0.1:12346").await.unwrap();
         info!("Server ready");
         con_tx.send(()).unwrap();
         info!("Waiting on next connection");
@@ -86,7 +86,7 @@ async fn split_communication() {
     info!("Waiting for server to be ready");
 
     con_rx.await.expect("Server not ready");
-    let tcp = TcpStream::connect("0.0.0.0:12346").await.expect("Failed to connect");
+    let tcp = TcpStream::connect("127.0.0.1:12346").await.expect("Failed to connect");
     let url = url::Url::parse("ws://localhost:12345/").unwrap();
     let (stream, _) = client_async(url, tcp).await.expect("Client failed to connect");
     let (mut tx, _rx) = stream.split();

--- a/tests/handshakes.rs
+++ b/tests/handshakes.rs
@@ -6,7 +6,7 @@ async fn handshakes() {
     let (tx, rx) = futures_channel::oneshot::channel();
 
     let f = async move {
-        let listener = TcpListener::bind("0.0.0.0:12345").await.unwrap();
+        let listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
         tx.send(()).unwrap();
         while let Ok((connection, _)) = listener.accept().await {
             let stream = accept_async(connection).await;
@@ -17,7 +17,7 @@ async fn handshakes() {
     tokio::spawn(f);
 
     rx.await.expect("Failed to wait for server to be ready");
-    let tcp = TcpStream::connect("0.0.0.0:12345").await.expect("Failed to connect");
+    let tcp = TcpStream::connect("127.0.0.1:12345").await.expect("Failed to connect");
     let url = url::Url::parse("ws://localhost:12345/").unwrap();
     let _stream = client_async(url, tcp).await.expect("Client failed to connect");
 }


### PR DESCRIPTION
As the title says, this changes all tests to run on 127.0.0.1 instead of 0.0.0.0.

When for example on MacOS you get a firewall warning for every time the code changes and the tests are run as the binary changed. Some firewalls even let the tests hang so they have to be cancelled and restarted several times.

By changing to 127.0.0.1 this warnings don't come as the binary won't listen for requests from external devices.