### PR TITLE
Add documentation about TLS features to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ Take a look at the `examples/` directory for client and server examples. You may
 
 This crate is based on [`tungstenite-rs`](https://github.com/snapview/tungstenite-rs) Rust WebSocket library and provides `Tokio` bindings and wrappers for it, so you
 can use it with non-blocking/asynchronous `TcpStream`s from and couple it together with other crates from `Tokio` stack.
+
+## Features
+
+As with [`tungstenite-rs`](https://github.com/snapview/tungstenite-rs) TLS is supported on all platforms using [`native-tls`](https://github.com/sfackler/rust-native-tls) or [`rustls`](https://github.com/ctz/rustls) through the `native-tls` and `rustls-tls` feature flags. Neither is enabled by default. If you require support for secure WebSockets (`wss://`) enable one of them.


### PR DESCRIPTION
Because I was struggling with this and did not think about looking into the Cargo.toml for the features, I would like to add a few lines to the README describing the features required for TLS support.