### PR TITLE
Add a function to connect with a specific connector

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -9,6 +9,9 @@ use tungstenite::{
 
 use crate::{domain, stream::MaybeTlsStream, IntoClientRequest, WebSocketStream};
 
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+use crate::Connector;
+
 /// Connect to a given URL.
 pub async fn connect_async<R>(
     request: R,
@@ -54,4 +57,35 @@ where
     {
         crate::tls::client_async_tls_with_config(request, socket, config, None).await
     }
+}
+
+/// The same as `connect_async()` but the one can specify a websocket configuration,
+/// and a TLS connector to use.
+/// Please refer to `connect_async()` for more details.
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+pub async fn connect_async_tls_with_config<R>(
+    request: R,
+    config: Option<WebSocketConfig>,
+    connector: Option<Connector>,
+) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), Error>
+where
+    R: IntoClientRequest + Unpin,
+{
+    let request = request.into_client_request()?;
+
+    let domain = domain(&request)?;
+    let port = request
+        .uri()
+        .port_u16()
+        .or_else(|| match request.uri().scheme_str() {
+            Some("wss") => Some(443),
+            Some("ws") => Some(80),
+            _ => None,
+        })
+        .ok_or(Error::Url(UrlError::UnsupportedUrlScheme))?;
+
+    let addr = format!("{}:{}", domain, port);
+    let try_socket = TcpStream::connect(addr).await;
+    let socket = try_socket.map_err(Error::Io)?;
+    crate::tls::client_async_tls_with_config(request, socket, config, connector).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,9 @@ pub use tls::{client_async_tls, client_async_tls_with_config, Connector};
 #[cfg(feature = "connect")]
 pub use connect::{connect_async, connect_async_with_config};
 
+#[cfg(all(any(feature = "native-tls", feature = "rustls-tls"), feature = "connect"))]
+pub use connect::connect_async_tls_with_config;
+
 #[cfg(feature = "stream")]
 pub use stream::MaybeTlsStream;
 


### PR DESCRIPTION
This makes reusing a tls connector much easier as you will not have to
set up the socket to connect on yourself. When using native-tls this
can save a considerable amount of memory.