### PR TITLE
Reduce crate package size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/tokio-tungstenite/0.15.0"
 repository = "https://github.com/snapview/tokio-tungstenite"
 version = "0.15.0"
 edition = "2018"
+include = ["examples/**/*", "src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 features = ["native-tls", "rustls-tls"]


### PR DESCRIPTION
Same as in https://github.com/snapview/tungstenite-rs/pull/229, reducing crate package size to improve download speed for everyone.

Especially big reductions here due to the removal of autobahn JSON files from the package.