### PR TITLE
Add `permessage-deflate` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+autobahn/client/
+autobahn/server/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ rustls-tls-native-roots = ["__rustls-tls", "rustls-native-certs"]
 rustls-tls-webpki-roots = ["__rustls-tls", "webpki-roots"]
 __rustls-tls = ["rustls", "tokio-rustls", "stream", "tungstenite/__rustls-tls", "webpki"]
 stream = []
+deflate = ["tungstenite/deflate"]
+# deflate-zlib = ["tungstenite/deflate-zlib"]
 
 [dependencies]
 log = "0.4"
@@ -32,7 +34,8 @@ pin-project = "1.0"
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
-version = "0.15.0"
+git = "https://github.com/kazk/tungstenite-rs"
+branch = "permessage-deflate"
 default-features = false
 
 [dependencies.native-tls-crate]
@@ -72,7 +75,11 @@ env_logger = "0.7"
 
 [[example]]
 name = "autobahn-client"
-required-features = ["connect"]
+required-features = ["connect", "deflate"]
+
+[[example]]
+name = "autobahn-server"
+required-features = ["deflate"]
 
 [[example]]
 name = "client"

--- a/autobahn/expected-results.json
+++ b/autobahn/expected-results.json
@@ -3,63 +3,63 @@
       "1.1.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_1_1.json"
       },
       "1.1.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_1_2.json"
       },
       "1.1.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_1_3.json"
       },
       "1.1.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_1_4.json"
       },
       "1.1.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_1_5.json"
       },
       "1.1.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 7,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_1_6.json"
       },
       "1.1.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 4,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_1_7.json"
       },
       "1.1.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 6,
+         "duration": 12,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_1_8.json"
       },
       "1.2.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_2_1.json"
       },
@@ -73,931 +73,931 @@
       "1.2.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_2_3.json"
       },
       "1.2.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_2_4.json"
       },
       "1.2.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_2_5.json"
       },
       "1.2.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 31,
+         "duration": 6,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_2_6.json"
       },
       "1.2.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 26,
+         "duration": 6,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_2_7.json"
       },
       "1.2.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 36,
+         "duration": 14,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_1_2_8.json"
       },
       "10.1.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 7,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_10_1_1.json"
       },
       "12.1.1": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 490,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_1.json"
       },
       "12.1.10": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 4346,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_10.json"
       },
       "12.1.11": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1257,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_11.json"
       },
       "12.1.12": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1830,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_12.json"
       },
       "12.1.13": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1819,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_13.json"
       },
       "12.1.14": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2484,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_14.json"
       },
       "12.1.15": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 4087,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_15.json"
       },
       "12.1.16": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 3933,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_16.json"
       },
       "12.1.17": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 3914,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_17.json"
       },
       "12.1.18": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 3891,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_18.json"
       },
       "12.1.2": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 387,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_2.json"
       },
       "12.1.3": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 245,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_3.json"
       },
       "12.1.4": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 287,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_4.json"
       },
       "12.1.5": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 459,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_5.json"
       },
       "12.1.6": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 559,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_6.json"
       },
       "12.1.7": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 817,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_7.json"
       },
       "12.1.8": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1305,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_8.json"
       },
       "12.1.9": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2262,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_1_9.json"
       },
       "12.2.1": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 201,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_1.json"
       },
       "12.2.10": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 18286,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_10.json"
       },
       "12.2.11": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1429,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_11.json"
       },
       "12.2.12": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2491,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_12.json"
       },
       "12.2.13": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 4218,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_13.json"
       },
       "12.2.14": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 8369,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_14.json"
       },
       "12.2.15": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 16487,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_15.json"
       },
       "12.2.16": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 16234,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_16.json"
       },
       "12.2.17": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 15925,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_17.json"
       },
       "12.2.18": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 15617,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_18.json"
       },
       "12.2.2": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 193,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_2.json"
       },
       "12.2.3": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 345,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_3.json"
       },
       "12.2.4": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 424,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_4.json"
       },
       "12.2.5": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 856,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_5.json"
       },
       "12.2.6": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1424,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_6.json"
       },
       "12.2.7": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2211,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_7.json"
       },
       "12.2.8": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 4061,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_8.json"
       },
       "12.2.9": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 7871,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_2_9.json"
       },
       "12.3.1": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 161,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_1.json"
       },
       "12.3.10": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 21632,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_10.json"
       },
       "12.3.11": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 1732,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_11.json"
       },
       "12.3.12": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 3099,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_12.json"
       },
       "12.3.13": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 5747,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_13.json"
       },
       "12.3.14": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 10949,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_14.json"
       },
       "12.3.15": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 21789,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_15.json"
       },
       "12.3.16": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 21489,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_16.json"
       },
       "12.3.17": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 21196,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_17.json"
       },
       "12.3.18": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 22421,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_18.json"
       },
       "12.3.2": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 160,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_2.json"
       },
       "12.3.3": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 224,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_3.json"
       },
       "12.3.4": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 380,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_4.json"
       },
       "12.3.5": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 990,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_5.json"
       },
       "12.3.6": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 1607,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_6.json"
       },
       "12.3.7": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2925,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_7.json"
       },
       "12.3.8": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 5461,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_8.json"
       },
       "12.3.9": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 10604,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_3_9.json"
       },
       "12.4.1": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 476,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_1.json"
       },
       "12.4.10": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 5076,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_10.json"
       },
       "12.4.11": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 851,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_11.json"
       },
       "12.4.12": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 1200,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_12.json"
       },
       "12.4.13": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 1710,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_13.json"
       },
       "12.4.14": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2850,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_14.json"
       },
       "12.4.15": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 5211,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_15.json"
       },
       "12.4.16": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 5017,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_16.json"
       },
       "12.4.17": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 4961,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_17.json"
       },
       "12.4.18": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 5002,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_18.json"
       },
       "12.4.2": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 469,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_2.json"
       },
       "12.4.3": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 496,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_3.json"
       },
       "12.4.4": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 580,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_4.json"
       },
       "12.4.5": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 678,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_5.json"
       },
       "12.4.6": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 868,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_6.json"
       },
       "12.4.7": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 1147,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_7.json"
       },
       "12.4.8": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1776,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_8.json"
       },
       "12.4.9": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2884,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_4_9.json"
       },
       "12.5.1": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 149,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_1.json"
       },
       "12.5.10": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 11907,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_10.json"
       },
       "12.5.11": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1128,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_11.json"
       },
       "12.5.12": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 1813,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_12.json"
       },
       "12.5.13": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 3569,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_13.json"
       },
       "12.5.14": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 7520,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_14.json"
       },
       "12.5.15": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 12700,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_15.json"
       },
       "12.5.16": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 11999,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_16.json"
       },
       "12.5.17": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 11739,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_17.json"
       },
       "12.5.18": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 11982,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_18.json"
       },
       "12.5.2": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 163,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_2.json"
       },
       "12.5.3": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 313,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_3.json"
       },
       "12.5.4": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 336,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_4.json"
       },
       "12.5.5": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 695,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_5.json"
       },
       "12.5.6": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 1057,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_6.json"
       },
       "12.5.7": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1751,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_7.json"
       },
       "12.5.8": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 3150,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_8.json"
       },
       "12.5.9": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 6072,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_12_5_9.json"
       },
       "13.1.1": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 235,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_1.json"
       },
       "13.1.10": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 3978,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_10.json"
       },
       "13.1.11": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 591,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_11.json"
       },
       "13.1.12": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 851,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_12.json"
       },
       "13.1.13": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 1346,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_13.json"
       },
       "13.1.14": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2212,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_14.json"
       },
       "13.1.15": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 4209,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_15.json"
       },
       "13.1.16": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 4009,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_16.json"
       },
       "13.1.17": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 4007,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_17.json"
       },
       "13.1.18": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 3975,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_18.json"
       },
       "13.1.2": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 265,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_2.json"
       },
       "13.1.3": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 272,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_3.json"
       },
       "13.1.4": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 338,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_4.json"
       },
       "13.1.5": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 482,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_5.json"
       },
       "13.1.6": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 570,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_6.json"
       },
       "13.1.7": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 823,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_7.json"
       },
       "13.1.8": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 1367,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_8.json"
       },
       "13.1.9": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2228,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_1_9.json"
       },
       "13.2.1": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 289,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_1.json"
       },
       "13.2.10": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 3957,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_10.json"
       },
       "13.2.11": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 569,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_11.json"
       },
       "13.2.12": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 839,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_12.json"
       },
       "13.2.13": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1255,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_13.json"
       },
       "13.2.14": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2198,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_14.json"
       },
       "13.2.15": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 4179,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_15.json"
       },
       "13.2.16": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 4,
+         "duration": 4024,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_16.json"
       },
       "13.2.17": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 4049,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_17.json"
       },
       "13.2.18": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 3886,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_18.json"
       },
       "13.2.2": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 282,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_2.json"
       },
       "13.2.3": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 319,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_3.json"
       },
       "13.2.4": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 407,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_4.json"
       },
       "13.2.5": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 468,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_5.json"
       },
       "13.2.6": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 559,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_6.json"
       },
       "13.2.7": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 818,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_7.json"
       },
       "13.2.8": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1287,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_8.json"
       },
       "13.2.9": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2175,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_2_9.json"
       },
@@ -1011,7 +1011,7 @@
       "13.3.10": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_3_10.json"
       },
@@ -1032,42 +1032,42 @@
       "13.3.13": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_3_13.json"
       },
       "13.3.14": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_3_14.json"
       },
       "13.3.15": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_3_15.json"
       },
       "13.3.16": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_3_16.json"
       },
       "13.3.17": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_3_17.json"
       },
       "13.3.18": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_3_18.json"
       },
@@ -1123,14 +1123,14 @@
       "13.3.9": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_3_9.json"
       },
       "13.4.1": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_4_1.json"
       },
@@ -1151,7 +1151,7 @@
       "13.4.12": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_4_12.json"
       },
@@ -1165,7 +1165,7 @@
       "13.4.14": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_4_14.json"
       },
@@ -1186,7 +1186,7 @@
       "13.4.17": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_4_17.json"
       },
@@ -1200,21 +1200,21 @@
       "13.4.2": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_4_2.json"
       },
       "13.4.3": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_4_3.json"
       },
       "13.4.4": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_4_4.json"
       },
@@ -1228,14 +1228,14 @@
       "13.4.6": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_4_6.json"
       },
       "13.4.7": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_4_7.json"
       },
@@ -1263,21 +1263,21 @@
       "13.5.10": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_10.json"
       },
       "13.5.11": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_11.json"
       },
       "13.5.12": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_12.json"
       },
@@ -1305,14 +1305,14 @@
       "13.5.16": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_16.json"
       },
       "13.5.17": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_17.json"
       },
@@ -1333,49 +1333,49 @@
       "13.5.3": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_3.json"
       },
       "13.5.4": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_4.json"
       },
       "13.5.5": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_5.json"
       },
       "13.5.6": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_6.json"
       },
       "13.5.7": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_7.json"
       },
       "13.5.8": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_8.json"
       },
       "13.5.9": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_5_9.json"
       },
@@ -1389,7 +1389,7 @@
       "13.6.10": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_10.json"
       },
@@ -1410,35 +1410,35 @@
       "13.6.13": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_13.json"
       },
       "13.6.14": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_14.json"
       },
       "13.6.15": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_15.json"
       },
       "13.6.16": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_16.json"
       },
       "13.6.17": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_17.json"
       },
@@ -1452,182 +1452,182 @@
       "13.6.2": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_2.json"
       },
       "13.6.3": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_3.json"
       },
       "13.6.4": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_4.json"
       },
       "13.6.5": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_5.json"
       },
       "13.6.6": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_6.json"
       },
       "13.6.7": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_7.json"
       },
       "13.6.8": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_8.json"
       },
       "13.6.9": {
          "behavior": "UNIMPLEMENTED",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_6_9.json"
       },
       "13.7.1": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 306,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_1.json"
       },
       "13.7.10": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 3931,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_10.json"
       },
       "13.7.11": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 562,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_11.json"
       },
       "13.7.12": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 801,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_12.json"
       },
       "13.7.13": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 1354,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_13.json"
       },
       "13.7.14": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2170,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_14.json"
       },
       "13.7.15": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 4121,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_15.json"
       },
       "13.7.16": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 3941,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_16.json"
       },
       "13.7.17": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 3915,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_17.json"
       },
       "13.7.18": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 4000,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_18.json"
       },
       "13.7.2": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 279,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_2.json"
       },
       "13.7.3": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 301,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_3.json"
       },
       "13.7.4": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 461,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_4.json"
       },
       "13.7.5": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 439,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_5.json"
       },
       "13.7.6": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 600,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_6.json"
       },
       "13.7.7": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 886,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_7.json"
       },
       "13.7.8": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 1255,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_8.json"
       },
       "13.7.9": {
-         "behavior": "UNIMPLEMENTED",
+         "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2173,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_13_7_9.json"
       },
@@ -1641,35 +1641,35 @@
       "2.10": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 6,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_2_10.json"
       },
       "2.11": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 10,
+         "duration": 26,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_2_11.json"
       },
       "2.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 3,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_2_2.json"
       },
       "2.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 3,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_2_3.json"
       },
       "2.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 3,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_2_4.json"
       },
@@ -1683,7 +1683,7 @@
       "2.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 9,
+         "duration": 27,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_2_6.json"
       },
@@ -1704,14 +1704,14 @@
       "2.9": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_2_9.json"
       },
       "3.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_3_1.json"
       },
@@ -1725,21 +1725,21 @@
       "3.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_3_3.json"
       },
       "3.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 5,
+         "duration": 10,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_3_4.json"
       },
       "3.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 4,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_3_5.json"
       },
@@ -1760,14 +1760,14 @@
       "4.1.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_4_1_1.json"
       },
       "4.1.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_4_1_2.json"
       },
@@ -1788,21 +1788,21 @@
       "4.1.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 7,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_4_1_5.json"
       },
       "4.2.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_4_2_1.json"
       },
       "4.2.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_4_2_2.json"
       },
@@ -1823,14 +1823,14 @@
       "4.2.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 6,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_4_2_5.json"
       },
       "5.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_1.json"
       },
@@ -1844,56 +1844,56 @@
       "5.11": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 5,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_11.json"
       },
       "5.12": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_12.json"
       },
       "5.13": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_13.json"
       },
       "5.14": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 3,
+         "duration": 10,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_14.json"
       },
       "5.15": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 3,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_15.json"
       },
       "5.16": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_16.json"
       },
       "5.17": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 2,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_17.json"
       },
       "5.18": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_18.json"
       },
@@ -1907,56 +1907,56 @@
       "5.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_5_2.json"
       },
       "5.20": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1005,
+         "duration": 1012,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_5_20.json"
       },
       "5.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_5_3.json"
       },
       "5.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_5_4.json"
       },
       "5.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 5,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_5_5.json"
       },
       "5.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_5_6.json"
       },
       "5.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_5_7.json"
       },
       "5.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 17,
+         "duration": 16,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_5_8.json"
       },
@@ -1970,105 +1970,105 @@
       "6.1.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 6,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_1_1.json"
       },
       "6.1.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 4,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_1_2.json"
       },
       "6.1.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 5,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_1_3.json"
       },
       "6.10.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_10_1.json"
       },
       "6.10.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_10_2.json"
       },
       "6.10.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_10_3.json"
       },
       "6.11.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_11_1.json"
       },
       "6.11.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_11_2.json"
       },
       "6.11.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_11_3.json"
       },
       "6.11.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_11_4.json"
       },
       "6.11.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_11_5.json"
       },
       "6.12.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_12_1.json"
       },
       "6.12.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_12_2.json"
       },
       "6.12.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_12_3.json"
       },
       "6.12.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_12_4.json"
       },
@@ -2082,63 +2082,63 @@
       "6.12.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_12_6.json"
       },
       "6.12.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_12_7.json"
       },
       "6.12.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_12_8.json"
       },
       "6.13.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_13_1.json"
       },
       "6.13.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_13_2.json"
       },
       "6.13.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_13_3.json"
       },
       "6.13.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_13_4.json"
       },
       "6.13.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_13_5.json"
       },
       "6.14.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_14_1.json"
       },
@@ -2152,49 +2152,49 @@
       "6.14.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_14_2.json"
       },
       "6.14.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_14_3.json"
       },
       "6.14.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_14_4.json"
       },
       "6.14.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_14_5.json"
       },
       "6.14.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_14_6.json"
       },
       "6.14.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_14_7.json"
       },
       "6.14.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_14_8.json"
       },
@@ -2208,14 +2208,14 @@
       "6.15.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_15_1.json"
       },
       "6.16.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_16_1.json"
       },
@@ -2257,14 +2257,14 @@
       "6.17.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 6,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_17_4.json"
       },
       "6.17.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_17_5.json"
       },
@@ -2292,70 +2292,70 @@
       "6.18.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_18_4.json"
       },
       "6.18.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_18_5.json"
       },
       "6.19.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_19_1.json"
       },
       "6.19.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_19_2.json"
       },
       "6.19.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_19_3.json"
       },
       "6.19.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_19_4.json"
       },
       "6.19.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_19_5.json"
       },
       "6.2.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 38,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_2_1.json"
       },
       "6.2.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 6,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_2_2.json"
       },
       "6.2.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 4,
+         "duration": 3,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_2_3.json"
       },
@@ -2369,161 +2369,161 @@
       "6.20.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_20_1.json"
       },
       "6.20.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_20_2.json"
       },
       "6.20.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_20_3.json"
       },
       "6.20.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_20_4.json"
       },
       "6.20.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_20_5.json"
       },
       "6.20.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_20_6.json"
       },
       "6.20.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_20_7.json"
       },
       "6.21.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_21_1.json"
       },
       "6.21.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_21_2.json"
       },
       "6.21.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 4,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_21_3.json"
       },
       "6.21.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_21_4.json"
       },
       "6.21.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_21_5.json"
       },
       "6.21.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_21_6.json"
       },
       "6.21.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_21_7.json"
       },
       "6.21.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_21_8.json"
       },
       "6.22.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 3,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_1.json"
       },
       "6.22.10": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_10.json"
       },
       "6.22.11": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_11.json"
       },
       "6.22.12": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_12.json"
       },
       "6.22.13": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_13.json"
       },
       "6.22.14": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_14.json"
       },
       "6.22.15": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_15.json"
       },
       "6.22.16": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 3,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_16.json"
       },
@@ -2537,14 +2537,14 @@
       "6.22.18": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_18.json"
       },
       "6.22.19": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_19.json"
       },
@@ -2558,14 +2558,14 @@
       "6.22.20": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_20.json"
       },
       "6.22.21": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_21.json"
       },
@@ -2579,21 +2579,21 @@
       "6.22.23": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_23.json"
       },
       "6.22.24": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 3,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_24.json"
       },
       "6.22.25": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 3,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_25.json"
       },
@@ -2607,70 +2607,70 @@
       "6.22.27": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_27.json"
       },
       "6.22.28": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_28.json"
       },
       "6.22.29": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_29.json"
       },
       "6.22.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 3,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_3.json"
       },
       "6.22.30": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_30.json"
       },
       "6.22.31": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_31.json"
       },
       "6.22.32": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_32.json"
       },
       "6.22.33": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_33.json"
       },
       "6.22.34": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_34.json"
       },
       "6.22.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 4,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_4.json"
       },
@@ -2684,42 +2684,42 @@
       "6.22.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_6.json"
       },
       "6.22.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_7.json"
       },
       "6.22.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_8.json"
       },
       "6.22.9": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 13,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_22_9.json"
       },
       "6.23.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_23_1.json"
       },
       "6.23.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 4,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_23_2.json"
       },
@@ -2733,21 +2733,21 @@
       "6.23.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_23_4.json"
       },
       "6.23.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_23_5.json"
       },
       "6.23.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_23_6.json"
       },
@@ -2775,7 +2775,7 @@
       "6.4.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1001,
+         "duration": 1002,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_4_1.json"
       },
@@ -2789,42 +2789,42 @@
       "6.4.3": {
          "behavior": "NON-STRICT",
          "behaviorClose": "OK",
-         "duration": 2002,
+         "duration": 2006,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_4_3.json"
       },
       "6.4.4": {
          "behavior": "NON-STRICT",
          "behaviorClose": "OK",
-         "duration": 2002,
+         "duration": 2011,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_6_4_4.json"
       },
       "6.5.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 8,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_5_1.json"
       },
       "6.5.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 19,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_5_2.json"
       },
       "6.5.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 6,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_5_3.json"
       },
       "6.5.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 3,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_5_4.json"
       },
@@ -2852,14 +2852,14 @@
       "6.6.11": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 5,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_6_11.json"
       },
       "6.6.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 3,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_6_2.json"
       },
@@ -2915,28 +2915,28 @@
       "6.7.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 2,
+         "duration": 8,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_7_1.json"
       },
       "6.7.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_7_2.json"
       },
       "6.7.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_7_3.json"
       },
       "6.7.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_7_4.json"
       },
@@ -2957,28 +2957,28 @@
       "6.9.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_9_1.json"
       },
       "6.9.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_9_2.json"
       },
       "6.9.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_9_3.json"
       },
       "6.9.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 2,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_6_9_4.json"
       },
@@ -3006,7 +3006,7 @@
       "7.1.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_1_4.json"
       },
@@ -3020,7 +3020,7 @@
       "7.1.6": {
          "behavior": "INFORMATIONAL",
          "behaviorClose": "INFORMATIONAL",
-         "duration": 16,
+         "duration": 12,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_1_6.json"
       },
@@ -3034,35 +3034,35 @@
       "7.13.2": {
          "behavior": "INFORMATIONAL",
          "behaviorClose": "INFORMATIONAL",
-         "duration": 2,
+         "duration": 1,
          "remoteCloseCode": 1002,
          "reportfile": "tungstenite_case_7_13_2.json"
       },
       "7.3.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 1,
+         "duration": 7,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_7_3_1.json"
       },
       "7.3.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_7_3_2.json"
       },
       "7.3.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_3_3.json"
       },
       "7.3.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_3_4.json"
       },
@@ -3076,14 +3076,14 @@
       "7.3.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_7_3_6.json"
       },
       "7.5.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": null,
          "reportfile": "tungstenite_case_7_5_1.json"
       },
@@ -3097,28 +3097,28 @@
       "7.7.10": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_10.json"
       },
       "7.7.11": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_11.json"
       },
       "7.7.12": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_12.json"
       },
       "7.7.13": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_13.json"
       },
@@ -3132,7 +3132,7 @@
       "7.7.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_3.json"
       },
@@ -3146,42 +3146,42 @@
       "7.7.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_5.json"
       },
       "7.7.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 8,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_6.json"
       },
       "7.7.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 8,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_7.json"
       },
       "7.7.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 8,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_8.json"
       },
       "7.7.9": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_7_7_9.json"
       },
       "7.9.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1002,
          "reportfile": "tungstenite_case_7_9_1.json"
       },
@@ -3209,21 +3209,21 @@
       "7.9.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1002,
          "reportfile": "tungstenite_case_7_9_5.json"
       },
       "7.9.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1002,
          "reportfile": "tungstenite_case_7_9_6.json"
       },
       "7.9.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 0,
+         "duration": 1,
          "remoteCloseCode": 1002,
          "reportfile": "tungstenite_case_7_9_7.json"
       },
@@ -3244,7 +3244,7 @@
       "9.1.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 5,
+         "duration": 3,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_1_1.json"
       },
@@ -3258,28 +3258,28 @@
       "9.1.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 22,
+         "duration": 23,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_1_3.json"
       },
       "9.1.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 110,
+         "duration": 78,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_1_4.json"
       },
       "9.1.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 205,
+         "duration": 137,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_1_5.json"
       },
       "9.1.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 320,
+         "duration": 375,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_1_6.json"
       },
@@ -3293,329 +3293,329 @@
       "9.2.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 6,
+         "duration": 4,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_2_2.json"
       },
       "9.2.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 16,
+         "duration": 11,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_2_3.json"
       },
       "9.2.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 123,
+         "duration": 58,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_2_4.json"
       },
       "9.2.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 169,
+         "duration": 105,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_2_5.json"
       },
       "9.2.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 360,
+         "duration": 215,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_2_6.json"
       },
       "9.3.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 638,
+         "duration": 160,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_3_1.json"
       },
       "9.3.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 209,
+         "duration": 73,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_3_2.json"
       },
       "9.3.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 93,
+         "duration": 54,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_3_3.json"
       },
       "9.3.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 64,
+         "duration": 36,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_3_4.json"
       },
       "9.3.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 43,
+         "duration": 34,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_3_5.json"
       },
       "9.3.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 50,
+         "duration": 55,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_3_6.json"
       },
       "9.3.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 45,
+         "duration": 37,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_3_7.json"
       },
       "9.3.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 51,
+         "duration": 34,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_3_8.json"
       },
       "9.3.9": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 57,
+         "duration": 35,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_3_9.json"
       },
       "9.4.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 608,
+         "duration": 93,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_4_1.json"
       },
       "9.4.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 192,
+         "duration": 36,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_4_2.json"
       },
       "9.4.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 75,
+         "duration": 23,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_4_3.json"
       },
       "9.4.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 44,
+         "duration": 21,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_4_4.json"
       },
       "9.4.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 29,
+         "duration": 40,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_4_5.json"
       },
       "9.4.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 39,
+         "duration": 25,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_4_6.json"
       },
       "9.4.7": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 35,
+         "duration": 21,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_4_7.json"
       },
       "9.4.8": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 24,
+         "duration": 22,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_4_8.json"
       },
       "9.4.9": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 29,
+         "duration": 22,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_4_9.json"
       },
       "9.5.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 795,
+         "duration": 429,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_5_1.json"
       },
       "9.5.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 425,
+         "duration": 156,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_5_2.json"
       },
       "9.5.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 228,
+         "duration": 100,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_5_3.json"
       },
       "9.5.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 114,
+         "duration": 47,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_5_4.json"
       },
       "9.5.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 84,
+         "duration": 40,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_5_5.json"
       },
       "9.5.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 51,
+         "duration": 23,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_5_6.json"
       },
       "9.6.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 799,
+         "duration": 299,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_6_1.json"
       },
       "9.6.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 429,
+         "duration": 138,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_6_2.json"
       },
       "9.6.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 214,
+         "duration": 94,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_6_3.json"
       },
       "9.6.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 127,
+         "duration": 50,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_6_4.json"
       },
       "9.6.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 80,
+         "duration": 31,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_6_5.json"
       },
       "9.6.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 57,
+         "duration": 20,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_6_6.json"
       },
       "9.7.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 127,
+         "duration": 293,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_7_1.json"
       },
       "9.7.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 121,
+         "duration": 183,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_7_2.json"
       },
       "9.7.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 124,
+         "duration": 95,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_7_3.json"
       },
       "9.7.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 146,
+         "duration": 204,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_7_4.json"
       },
       "9.7.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 196,
+         "duration": 113,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_7_5.json"
       },
       "9.7.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 351,
+         "duration": 191,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_7_6.json"
       },
       "9.8.1": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 95,
+         "duration": 162,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_8_1.json"
       },
       "9.8.2": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 119,
+         "duration": 151,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_8_2.json"
       },
       "9.8.3": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 115,
+         "duration": 95,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_8_3.json"
       },
       "9.8.4": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 134,
+         "duration": 147,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_8_4.json"
       },
       "9.8.5": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 187,
+         "duration": 109,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_8_5.json"
       },
       "9.8.6": {
          "behavior": "OK",
          "behaviorClose": "OK",
-         "duration": 328,
+         "duration": 173,
          "remoteCloseCode": 1000,
          "reportfile": "tungstenite_case_9_8_6.json"
       }

--- a/examples/autobahn-client.rs
+++ b/examples/autobahn-client.rs
@@ -1,8 +1,8 @@
 use futures_util::{SinkExt, StreamExt};
 use log::*;
 use tokio_tungstenite::{
-    connect_async,
-    tungstenite::{Error, Result},
+    connect_async, connect_async_with_config,
+    tungstenite::{extensions::DeflateConfig, protocol::WebSocketConfig, Error, Result},
 };
 use url::Url;
 
@@ -34,7 +34,14 @@ async fn run_test(case: u32) -> Result<()> {
         Url::parse(&format!("ws://localhost:9001/runCase?case={}&agent={}", case, AGENT))
             .expect("Bad testcase URL");
 
-    let (mut ws_stream, _) = connect_async(case_url).await?;
+    let (mut ws_stream, _) = connect_async_with_config(
+        case_url,
+        Some(WebSocketConfig {
+            compression: Some(DeflateConfig::default()),
+            ..WebSocketConfig::default()
+        }),
+    )
+    .await?;
     while let Some(msg) = ws_stream.next().await {
         let msg = msg?;
         if msg.is_text() || msg.is_binary() {

--- a/scripts/autobahn-client.sh
+++ b/scripts/autobahn-client.sh
@@ -32,5 +32,5 @@ docker run -d --rm \
     wstest -m fuzzingserver -s 'autobahn/fuzzingserver.json'
 
 sleep 3
-cargo run --release --example autobahn-client
+cargo run --release --example autobahn-client --features=connect,deflate
 test_diff

--- a/scripts/autobahn-server.sh
+++ b/scripts/autobahn-server.sh
@@ -22,7 +22,7 @@ function test_diff() {
     fi
 }
 
-cargo run --release --example autobahn-server & WSSERVER_PID=$!
+cargo run --release --example autobahn-server --features=deflate & WSSERVER_PID=$!
 sleep 3
 
 docker run --rm \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tungstenite::{
     client::IntoClientRequest,
     error::Error as WsError,
+    extensions::Extensions,
     handshake::{
         client::{ClientHandshake, Response},
         server::{Callback, NoCallback},
@@ -193,6 +194,23 @@ impl<S> WebSocketStream<S> {
     {
         handshake::without_handshake(stream, move |allow_std| {
             WebSocket::from_raw_socket(allow_std, role, config)
+        })
+        .await
+    }
+
+    /// Convert a raw socket into a WebSocketStream without performing a
+    /// handshake.
+    pub async fn from_raw_socket_with_extensions(
+        stream: S,
+        role: Role,
+        config: Option<WebSocketConfig>,
+        extensions: Option<Extensions>,
+    ) -> Self
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        handshake::without_handshake(stream, move |allow_std| {
+            WebSocket::from_raw_socket_with_extensions(allow_std, role, config, extensions)
         })
         .await
     }


### PR DESCRIPTION
Adds `WebSocketStream::from_raw_socket_with_compression` to enable compression without handshake for crates like `warp` and `axum`.

See https://github.com/snapview/tungstenite-rs/pull/235