### PR TITLE
Re-port #90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ stream = []
 
 [dependencies]
 log = "0.4"
-futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ stream = []
 [dependencies]
 log = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["async-await", "sink", "std"] }
-pin-project = "1.0"
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]


### PR DESCRIPTION
This is essentially a re-port of #90 to the latest version of tokio-tungstenite - the PR has merge conflicts and I assume that's why it hasn't been touched at all. I'm hoping that this re-port will make it possible to apply the changes. I also removed the unused `async-await` feature on futures-util.

Would love to see this merged since most other libraries - e.g. async-tungstenite or hyper - moved away from pin-project and this allows for much faster compile times.

As mentioned in #90, this might be a breaking change, but I am not sure. It does work fine for my existing uses and the examples, however.