### PR TITLE
Upgrade to rustls 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 [dependencies.tungstenite]
 version = "0.15.0"
 default-features = false
+git = "https://github.com/dnaka91/tungstenite-rs.git"
+rev = "f4bb653aa03665a83bd98068432602f07cd5634b"
 
 [dependencies.native-tls-crate]
 optional = true
@@ -41,11 +43,13 @@ version = "0.2.7"
 
 [dependencies.rustls]
 optional = true
-version = "0.19.0"
+version = "0.20.0"
 
 [dependencies.rustls-native-certs]
 optional = true
-version = "0.5.0"
+version = "0.6.0"
+git = "https://github.com/rustls/rustls-native-certs.git"
+rev = "87b84b51bcf38eb9d377e0f5606c444ced43cc60"
 
 [dependencies.tokio-native-tls]
 optional = true
@@ -53,15 +57,15 @@ version = "0.3.0"
 
 [dependencies.tokio-rustls]
 optional = true
-version = "0.22.0"
+version = "0.23.0"
 
 [dependencies.webpki]
 optional = true
-version = "0.21.4"
+version = "0.22.0"
 
 [dependencies.webpki-roots]
 optional = true
-version = "0.21.0"
+version = "0.22.1"
 
 [dev-dependencies]
 futures-channel = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,8 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
-version = "0.15.0"
+version = "0.16.0"
 default-features = false
-git = "https://github.com/dnaka91/tungstenite-rs.git"
-rev = "f4bb653aa03665a83bd98068432602f07cd5634b"
 
 [dependencies.native-tls-crate]
 optional = true
@@ -47,9 +45,7 @@ version = "0.20.0"
 
 [dependencies.rustls-native-certs]
 optional = true
-version = "0.6.0"
-git = "https://github.com/rustls/rustls-native-certs.git"
-rev = "87b84b51bcf38eb9d377e0f5606c444ced43cc60"
+version = "0.6.1"
 
 [dependencies.tokio-native-tls]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ impl<S> WebSocketStream<S> {
     {
         trace!("{}:{} WebSocketStream.with_context", file!(), line!());
         if let Some((kind, ctx)) = ctx {
-            self.inner.get_mut().set_waker(kind, &ctx.waker());
+            self.inner.get_mut().set_waker(kind, ctx.waker());
         }
         f(&mut self.inner)
     }
@@ -236,7 +236,7 @@ impl<S> WebSocketStream<S> {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        &self.inner.get_ref().get_ref()
+        self.inner.get_ref().get_ref()
     }
 
     /// Returns a mutable reference to the inner stream.


### PR DESCRIPTION
Upgrading to `rustls` version `0.20`, same as in https://github.com/snapview/tungstenite-rs/pull/244.

Marked as draft as it depends on `rustls-native-certs` and the mentioned PR for `tungstenite`.
