### PR TITLE
Bump up dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
-version = "0.16.0"
+version = "0.17.1"
 default-features = false
 
 [dependencies.native-tls-crate]
@@ -67,7 +67,7 @@ version = "0.22.1"
 futures-channel = "0.3"
 tokio = { version = "1.0.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
 url = "2.0.0"
-env_logger = "0.7"
+env_logger = "0.9"
 
 [[example]]
 name = "autobahn-client"


### PR DESCRIPTION
Simply bumping `tungstenite` to latest `0.17.1` and bumping `env_logger` as well, while we're already ad it.

The motivation for this is to remove duplicat dependencies on `sha-1`.