### PR TITLE
Fix `poll_close` returning WouldBlock error kind

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ where
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         if self.closing {
-            // After queing it, we call `write_pending` to drive the close handshake to completion.
+            // After queueing it, we call `write_pending` to drive the close handshake to completion.
             match (*self).with_context(Some((ContextWaker::Write, cx)), |s| s.write_pending()) {
                 Ok(()) => Poll::Ready(Ok(())),
                 Err(::tungstenite::Error::ConnectionClosed) => Poll::Ready(Ok(())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ where
 #[derive(Debug)]
 pub struct WebSocketStream<S> {
     inner: WebSocket<AllowStd<S>>,
+    closing: bool,
 }
 
 impl<S> WebSocketStream<S> {
@@ -215,7 +216,7 @@ impl<S> WebSocketStream<S> {
     }
 
     pub(crate) fn new(ws: WebSocket<AllowStd<S>>) -> Self {
-        WebSocketStream { inner: ws }
+        WebSocketStream { inner: ws, closing: false }
     }
 
     fn with_context<F, R>(&mut self, ctx: Option<(ContextWaker, &mut Context<'_>)>, f: F) -> R
@@ -294,9 +295,7 @@ where
     fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
         match (*self).with_context(None, |s| s.write_message(item)) {
             Ok(()) => Ok(()),
-            Err(::tungstenite::Error::Io(ref err))
-                if err.kind() == std::io::ErrorKind::WouldBlock =>
-            {
+            Err(::tungstenite::Error::Io(err)) if err.kind() == std::io::ErrorKind::WouldBlock => {
                 // the message was accepted and queued
                 // isn't an error.
                 Ok(())
@@ -313,12 +312,34 @@ where
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        match (*self).with_context(Some((ContextWaker::Write, cx)), |s| s.close(None)) {
-            Ok(()) => Poll::Ready(Ok(())),
-            Err(::tungstenite::Error::ConnectionClosed) => Poll::Ready(Ok(())),
-            Err(err) => {
-                debug!("websocket close error: {}", err);
-                Poll::Ready(Err(err))
+        if self.closing {
+            // After queing it, we call `write_pending` to drive the close handshake to completion.
+            match (*self).with_context(Some((ContextWaker::Write, cx)), |s| s.write_pending()) {
+                Ok(()) => Poll::Ready(Ok(())),
+                Err(::tungstenite::Error::ConnectionClosed) => Poll::Ready(Ok(())),
+                Err(::tungstenite::Error::Io(err))
+                    if err.kind() == std::io::ErrorKind::WouldBlock =>
+                {
+                    trace!("WouldBlock");
+                    Poll::Pending
+                }
+                Err(err) => Poll::Ready(Err(err)),
+            }
+        } else {
+            match (*self).with_context(Some((ContextWaker::Write, cx)), |s| s.close(None)) {
+                Ok(()) => Poll::Ready(Ok(())),
+                Err(::tungstenite::Error::ConnectionClosed) => Poll::Ready(Ok(())),
+                Err(::tungstenite::Error::Io(err))
+                    if err.kind() == std::io::ErrorKind::WouldBlock =>
+                {
+                    trace!("WouldBlock");
+                    self.closing = true;
+                    Poll::Pending
+                }
+                Err(err) => {
+                    debug!("websocket close error: {}", err);
+                    Poll::Ready(Err(err))
+                }
             }
         }
     }


### PR DESCRIPTION
Currently, `poll_close` is not checking for `io::ErrorKind::WouldBlock` on error, and instead it is bumbled up.
For instance, calling the [`close` helper from `SinkExt`](https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.close):
```rust
ws.close().await.unwrap();
```
will cause a panic when `WouldBlock` occurs, instead of simply polling as expected.

This patch addresses this by returning `Poll::Pending` and then polling `write_pending` to drive the close operation to completion.