### PR TITLE
Implement `Source` from `mio` for `WebSocketStream` as a feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.envrc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ features = ["native-tls", "__rustls-tls"]
 
 [features]
 default = ["connect"]
-connect = ["stream", "tokio/net"]
+connect = ["stream", "tokio/net", "mio"]
 native-tls = ["native-tls-crate", "tokio-native-tls", "stream", "tungstenite/native-tls"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored", "tungstenite/native-tls-vendored"]
 rustls-tls-native-roots = ["__rustls-tls", "rustls-native-certs"]
 rustls-tls-webpki-roots = ["__rustls-tls", "webpki-roots"]
 __rustls-tls = ["rustls", "tokio-rustls", "stream", "tungstenite/__rustls-tls", "webpki"]
 stream = []
+mio = ["dep:mio"]
 
 [dependencies]
 log = "0.4"
@@ -62,6 +63,10 @@ version = "0.22.0"
 [dependencies.webpki-roots]
 optional = true
 version = "0.22.1"
+
+[dependencies.mio]
+optional = true
+version = "0.8"
 
 [dev-dependencies]
 futures-channel = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,9 @@ pub use connect::connect_async_tls_with_config;
 #[cfg(feature = "stream")]
 pub use stream::MaybeTlsStream;
 
+#[cfg(feature = "mio")]
+use mio::{Interest, Registry, Token, event::Source};
+
 use tungstenite::protocol::CloseFrame;
 
 /// Creates a WebSocket handshake from a request and a stream.
@@ -356,6 +359,31 @@ where
                 Poll::Ready(Err(err))
             }
         }
+    }
+}
+
+#[cfg(feature = "mio")]
+impl<S: AsyncRead + AsyncWrite + Unpin + Source> Source for WebSocketStream<S> {
+    fn register(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> std::io::Result<()> {
+        self.get_mut().register(registry, token, interests)
+    }
+
+    fn reregister(
+        &mut self,
+        registry: &Registry,
+        token: Token,
+        interests: Interest,
+    ) -> std::io::Result<()> {
+        self.get_mut().reregister(registry, token, interests)
+    }
+
+    fn deregister(&mut self, registry: &Registry) -> std::io::Result<()> {
+        self.get_mut().deregister(registry)
     }
 }
 


### PR DESCRIPTION
Quick and dirty commit to implement the [`Source`] trait from [`mio`] to be able to poll on the `WebSocketStream` struct as a separate feature under `mio`. Did it because I was going to use it in my own code that uses `mio` to poll but I wasn't able to find an easy way to wrap `WebSocketStream`.

If there's an easy way to do this in user code please do let me know (even though I don't think it's a bad idea to implement it at the dependency level, considering it's also called *tokio*-tungstenite), as the compiler does *not* like me implementing traits, which are defined outside of my crate, for types that are defined outside of my crate. Either one has to be defined in the same crate, per [E0117].

[`Source`]: https://docs.rs/mio/latest/mio/event/trait.Source.html
[`mio`]: https://github.com/tokio-rs/mio
[E0117]: https://github.com/rust-lang/rust/blob/master/compiler/rustc_error_codes/src/error_codes/E0117.md