### PR TITLE
Don't consider it an error if the connection is closed while flushing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,10 +334,8 @@ where
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         (*self).with_context(Some((ContextWaker::Write, cx)), |s| cvt(s.write_pending())).map(
             |result| match result {
-                // It's not an error for the WebSocket to have closed normally.
-                // Note: `tungstenite` will only return this if a close frame has been sent, and
-                // doesn't allow sending anything else after that, so this can't arise when trying
-                // to flush something other than a close frame.
+                // It's not an error for the WebSocket to close while flushing if we're supposed to
+                // be closing - that just means that our close frame got flushed.
                 Err(::tungstenite::Error::ConnectionClosed) if self.closing => Ok(()),
                 other => other,
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ where
                 // Note: `tungstenite` will only return this if a close frame has been sent, and
                 // doesn't allow sending anything else after that, so this can't arise when trying
                 // to flush something other than a close frame.
-                Err(::tungstenite::Error::ConnectionClosed) => Ok(()),
+                Err(::tungstenite::Error::ConnectionClosed) if self.closing => Ok(()),
                 other => other,
             },
         )


### PR DESCRIPTION
It's perfectly fine for the connection to close while flushing if the thing you're flushing is a responding close frame.
I'm pretty sure that there isn't any other scenario where `tungstenite` will return `Error::ConnectionClosed` when writing.