### PR TITLE
Make handshake dependencies optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ include = ["examples/**/*", "src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 features = ["native-tls", "__rustls-tls"]
 
 [features]
-default = ["connect"]
-connect = ["stream", "tokio/net"]
+default = ["connect", "handshake"]
+connect = ["stream", "tokio/net", "handshake"]
+handshake = ["tungstenite/handshake"]
 native-tls = ["native-tls-crate", "tokio-native-tls", "stream", "tungstenite/native-tls"]
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored", "tungstenite/native-tls-vendored"]
 rustls-tls-native-roots = ["__rustls-tls", "rustls-native-certs"]
@@ -32,6 +33,7 @@ tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
 version = "0.17.3"
+path = "../tungstenite-rs"
 default-features = false
 
 [dependencies.native-tls-crate]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
-version = "0.17.3"
-path = "../tungstenite-rs"
+version = "0.18.0"
 default-features = false
 
 [dependencies.native-tls-crate]

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -1,7 +1,6 @@
-use crate::{
-    compat::{AllowStd, SetWaker},
-    WebSocketStream,
-};
+#[cfg(feature = "handshake")]
+use crate::compat::SetWaker;
+use crate::{compat::AllowStd, WebSocketStream};
 use log::*;
 use std::{
     future::Future,
@@ -10,12 +9,14 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::io::{AsyncRead, AsyncWrite};
+use tungstenite::WebSocket;
+#[cfg(feature = "handshake")]
 use tungstenite::{
     handshake::{
         client::Response, server::Callback, HandshakeError as Error, HandshakeRole,
         MidHandshake as WsHandshake,
     },
-    ClientHandshake, ServerHandshake, WebSocket,
+    ClientHandshake, ServerHandshake,
 };
 
 pub(crate) async fn without_handshake<F, S>(stream: S, f: F) -> WebSocketStream<S>
@@ -53,19 +54,24 @@ where
     }
 }
 
+#[cfg(feature = "handshake")]
 struct MidHandshake<Role: HandshakeRole>(Option<WsHandshake<Role>>);
 
+#[cfg(feature = "handshake")]
 enum StartedHandshake<Role: HandshakeRole> {
     Done(Role::FinalResult),
     Mid(WsHandshake<Role>),
 }
 
+#[cfg(feature = "handshake")]
 struct StartedHandshakeFuture<F, S>(Option<StartedHandshakeFutureInner<F, S>>);
+#[cfg(feature = "handshake")]
 struct StartedHandshakeFutureInner<F, S> {
     f: F,
     stream: S,
 }
 
+#[cfg(feature = "handshake")]
 async fn handshake<Role, F, S>(stream: S, f: F) -> Result<Role::FinalResult, Error<Role>>
 where
     Role: HandshakeRole + Unpin,
@@ -84,6 +90,7 @@ where
     }
 }
 
+#[cfg(feature = "handshake")]
 pub(crate) async fn client_handshake<F, S>(
     stream: S,
     f: F,
@@ -102,6 +109,7 @@ where
     Ok((WebSocketStream::new(s), r))
 }
 
+#[cfg(feature = "handshake")]
 pub(crate) async fn server_handshake<C, F, S>(
     stream: S,
     f: F,
@@ -120,6 +128,7 @@ where
     Ok(WebSocketStream::new(s))
 }
 
+#[cfg(feature = "handshake")]
 impl<Role, F, S> Future for StartedHandshakeFuture<F, S>
 where
     Role: HandshakeRole,
@@ -143,6 +152,7 @@ where
     }
 }
 
+#[cfg(feature = "handshake")]
 impl<Role> Future for MidHandshake<Role>
 where
     Role: HandshakeRole + Unpin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,14 +35,17 @@ use std::{
 };
 use tokio::io::{AsyncRead, AsyncWrite};
 
+#[cfg(feature = "handshake")]
 use tungstenite::{
     client::IntoClientRequest,
-    error::Error as WsError,
     handshake::{
         client::{ClientHandshake, Response},
         server::{Callback, NoCallback},
         HandshakeError,
     },
+};
+use tungstenite::{
+    error::Error as WsError,
     protocol::{Message, Role, WebSocket, WebSocketConfig},
 };
 
@@ -74,6 +77,7 @@ use tungstenite::protocol::CloseFrame;
 ///
 /// This is typically used for clients who have already established, for
 /// example, a TCP connection to the remote server.
+#[cfg(feature = "handshake")]
 pub async fn client_async<'a, R, S>(
     request: R,
     stream: S,
@@ -87,6 +91,7 @@ where
 
 /// The same as `client_async()` but the one can specify a websocket configuration.
 /// Please refer to `client_async()` for more details.
+#[cfg(feature = "handshake")]
 pub async fn client_async_with_config<'a, R, S>(
     request: R,
     stream: S,
@@ -118,6 +123,7 @@ where
 /// This is typically used after a socket has been accepted from a
 /// `TcpListener`. That socket is then passed to this function to perform
 /// the server half of the accepting a client's websocket connection.
+#[cfg(feature = "handshake")]
 pub async fn accept_async<S>(stream: S) -> Result<WebSocketStream<S>, WsError>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -127,6 +133,7 @@ where
 
 /// The same as `accept_async()` but the one can specify a websocket configuration.
 /// Please refer to `accept_async()` for more details.
+#[cfg(feature = "handshake")]
 pub async fn accept_async_with_config<S>(
     stream: S,
     config: Option<WebSocketConfig>,
@@ -142,6 +149,7 @@ where
 /// This function does the same as `accept_async()` but accepts an extra callback
 /// for header processing. The callback receives headers of the incoming
 /// requests and is able to add extra headers to the reply.
+#[cfg(feature = "handshake")]
 pub async fn accept_hdr_async<S, C>(stream: S, callback: C) -> Result<WebSocketStream<S>, WsError>
 where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -152,6 +160,7 @@ where
 
 /// The same as `accept_hdr_async()` but the one can specify a websocket configuration.
 /// Please refer to `accept_hdr_async()` for more details.
+#[cfg(feature = "handshake")]
 pub async fn accept_hdr_async_with_config<S, C>(
     stream: S,
     callback: C,


### PR DESCRIPTION
This is the PR I promised in snapview/tungstenite-rs#296.
It requires snapview/tungstenite-rs#300 to be merged and released before we can release this.

This adds a cargo feature named `handshake` which is enabled by default. Disabling it removes the handshake feature of tungstenite.