### PR TITLE
New API `connect_to_raw_socket_async` for raw socket.

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -1,5 +1,6 @@
 //! Connection helper.
 use tokio::net::TcpStream;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 use tungstenite::{
     error::{Error, UrlError},
@@ -52,13 +53,14 @@ where
 }
 
 /// connect to an exist stream socket, and upgrade to websocket
-pub async fn connect_to_raw_socket_async<R>(
+pub async fn connect_to_raw_socket_async<R, S>(
     request: R,
     config: Option<WebSocketConfig>,
-    stream: TcpStream,
-) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), Error>
+    stream: S,
+) -> Result<(WebSocketStream<MaybeTlsStream<S>>, Response), Error>
 where
     R: IntoClientRequest + Unpin,
+    S: 'static + AsyncRead + AsyncWrite + Send + Unpin,
 {
     let request = request.into_client_request()?;
     crate::tls::client_async_tls_with_config(request, stream, config, None).await

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -51,6 +51,19 @@ where
     crate::tls::client_async_tls_with_config(request, socket, config, None).await
 }
 
+/// connect to an exist stream socket, and upgrade to websocket
+pub async fn connect_to_raw_socket_async<R>(
+    request: R,
+    config: Option<WebSocketConfig>,
+    stream: TcpStream,
+) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), Error>
+where
+    R: IntoClientRequest + Unpin,
+{
+    let request = request.into_client_request()?;
+    crate::tls::client_async_tls_with_config(request, stream, config, None).await
+}
+
 /// The same as `connect_async()` but the one can specify a websocket configuration,
 /// and a TLS connector to use.
 /// Please refer to `connect_async()` for more details.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub use tls::Connector;
 pub use tls::{client_async_tls, client_async_tls_with_config};
 
 #[cfg(feature = "connect")]
-pub use connect::{connect_async, connect_async_with_config};
+pub use connect::{connect_async, connect_async_with_config, connect_to_raw_socket_async};
 
 #[cfg(all(any(feature = "native-tls", feature = "__rustls-tls"), feature = "connect"))]
 pub use connect::connect_async_tls_with_config;


### PR DESCRIPTION
use the exiist raw stream socket make it act as WebSocket client. likes
```
    let url = "ws://123.45.67.89:1234/my_path";
    let stream = tokio::net::TcpStream::connect(("123.45.67.89", 1234)).await?;
    let (ws_stream, _) = connect_to_raw_socket_async(url, None, stream).await?;
    ...
```

