### PR TITLE
Replace deprecated rustfmt configuration

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,4 +4,4 @@
 # Break complex but short statements a bit less.
 use_small_heuristics = "Max"
 
-merge_imports = true
+imports_granularity = "Crate"


### PR DESCRIPTION
```
Warning: the `merge_imports` option is deprecated. Use `imports_granularity="Crate"` instead
```