### PR TITLE
Improve CI build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get install libssl-dev
 
       - name: Install cargo-hack
-        run: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
 
       - name: Check
         run: cargo hack check --feature-powerset --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      - name: Install and configure docker
-        uses: docker-practice/actions-setup-docker@v1
-
       - name: Running Autobahn TestSuite for client
         run: ./scripts/autobahn-client.sh
 


### PR DESCRIPTION
The Ubuntu images already come with docker and `cargo hack` is now installed with [`taiki-e/install-action`](https://github.com/taiki-e/install-action).