### PR TITLE
Implement tungstenite::stream::NoDelay for MaybeTlsStream

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -6,6 +6,7 @@
 use std::{
     pin::Pin,
     task::{Context, Poll},
+    io::{Read, Write},
 };
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
@@ -79,7 +80,9 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for MaybeTlsStream<S> {
     }
 }
 
-impl tungstenite::stream::NoDelay for MaybeTlsStream<tokio::net::TcpStream>  {
+impl<S> tungstenite::stream::NoDelay for MaybeTlsStream<S>
+    where S: Read + Write + tungstenite::stream::NoDelay
+{
     fn set_nodelay(&mut self, nodelay: bool) -> Result<(), std::io::Error> {
         match self {
             MaybeTlsStream::Plain(ref mut s) => s.set_nodelay(nodelay),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,12 +4,13 @@
 //! `native_tls` or `openssl` will work as long as there is a TLS stream supporting standard
 //! `Read + Write` traits.
 use std::{
+    io::{Read, Write},
     pin::Pin,
     task::{Context, Poll},
-    io::{Read, Write},
 };
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tungstenite::stream::NoDelay;
 
 /// A stream that might be protected with TLS.
 #[non_exhaustive]
@@ -80,9 +81,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for MaybeTlsStream<S> {
     }
 }
 
-impl<S> tungstenite::stream::NoDelay for MaybeTlsStream<S>
-    where S: Read + Write + tungstenite::stream::NoDelay
-{
+impl<S: Read + Write + NoDelay> NoDelay for MaybeTlsStream<S> {
     fn set_nodelay(&mut self, nodelay: bool) -> Result<(), std::io::Error> {
         match self {
             MaybeTlsStream::Plain(ref mut s) => s.set_nodelay(nodelay),

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -78,3 +78,15 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for MaybeTlsStream<S> {
         }
     }
 }
+
+impl tungstenite::stream::NoDelay for MaybeTlsStream<tokio::net::TcpStream>  {
+    fn set_nodelay(&mut self, nodelay: bool) -> Result<(), std::io::Error> {
+        match self {
+            MaybeTlsStream::Plain(ref mut s) => s.set_nodelay(nodelay),
+            #[cfg(feature = "native-tls")]
+            MaybeTlsStream::NativeTls(ref mut s) => s.set_nodelay(nodelay),
+            #[cfg(feature = "__rustls-tls")]
+            MaybeTlsStream::Rustls(ref mut s) => s.set_nodelay(nodelay),
+        }
+    }
+}


### PR DESCRIPTION
`tungstenite::stream::NoDelay` is implemented for `tungstenite::MaybeTLsStream` since [v0.15.0](https://github.com/snapview/tungstenite-rs/commit/32450ae5af0070c7f3fd8341d244525119672506#diff-aa0a8d713ea64389a4b4916384d286b01c0de291edf10fec2f213123419e2647R128) but it's not implemented for the  `tokio_tungstenite::MaybeTLsStream` wrapper, this pull request fix this.
 