### PR TITLE
Update dependencies and set rust-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/tokio-tungstenite/0.18.0"
 repository = "https://github.com/snapview/tokio-tungstenite"
 version = "0.18.0"
 edition = "2018"
+rust-version = "1.63"
 include = ["examples/**/*", "src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
@@ -27,34 +28,34 @@ __rustls-tls = ["rustls", "tokio-rustls", "stream", "tungstenite/__rustls-tls", 
 stream = []
 
 [dependencies]
-log = "0.4"
-futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
-tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
+log = "0.4.17"
+futures-util = { version = "0.3.28", default-features = false, features = ["sink", "std"] }
+tokio = { version = "1.27.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
-version = "0.18.0"
+version = "0.19.0"
 default-features = false
 
 [dependencies.native-tls-crate]
 optional = true
 package = "native-tls"
-version = "0.2.7"
+version = "0.2.11"
 
 [dependencies.rustls]
 optional = true
-version = "0.20.0"
+version = "0.21.0"
 
 [dependencies.rustls-native-certs]
 optional = true
-version = "0.6.1"
+version = "0.6.2"
 
 [dependencies.tokio-native-tls]
 optional = true
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies.tokio-rustls]
 optional = true
-version = "0.23.0"
+version = "0.24.0"
 
 [dependencies.webpki]
 optional = true
@@ -62,14 +63,14 @@ version = "0.22.0"
 
 [dependencies.webpki-roots]
 optional = true
-version = "0.22.1"
+version = "0.23.0"
 
 [dev-dependencies]
-futures-channel = "0.3"
-hyper = { version = "0.14", default-features = false, features = ["http1", "server", "tcp"] }
-tokio = { version = "1.0.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
-url = "2.0.0"
-env_logger = "0.9"
+futures-channel = "0.3.28"
+hyper = { version = "0.14.25", default-features = false, features = ["http1", "server", "tcp"] }
+tokio = { version = "1.27.0", default-features = false, features = ["io-std", "macros", "net", "rt-multi-thread", "time"] }
+url = "2.3.1"
+env_logger = "0.10.0"
 
 [[example]]
 name = "autobahn-client"

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -97,7 +97,7 @@ mod encryption {
                                 for cert in rustls_native_certs::load_native_certs()? {
                                     root_store
                                         .add(&rustls::Certificate(cert.0))
-                                        .map_err(TlsError::Webpki)?;
+                                        .map_err(TlsError::Rustls)?;
                                 }
                             }
                             #[cfg(feature = "rustls-tls-webpki-roots")]


### PR DESCRIPTION
Supported rust-version before this change was 1.63, so upgrading dependencies had no effect.

This is particularly useful since tungstenite has upgrade to 0.19, but a few more dependencies are coming along for the ride as well.