### PR TITLE
Use re-exported tungstenite types so its easier to copy examples and …

### DIFF
--- a/examples/autobahn-server.rs
+++ b/examples/autobahn-server.rs
@@ -2,7 +2,10 @@ use futures_util::{SinkExt, StreamExt};
 use log::*;
 use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream};
-use tokio_tungstenite::{accept_async, tungstenite::Error, tungstenite::Result};
+use tokio_tungstenite::{
+    accept_async,
+    tungstenite::{Error, Result},
+};
 
 async fn accept_connection(peer: SocketAddr, stream: TcpStream) {
     if let Err(e) = handle_connection(peer, stream).await {

--- a/examples/autobahn-server.rs
+++ b/examples/autobahn-server.rs
@@ -2,8 +2,7 @@ use futures_util::{SinkExt, StreamExt};
 use log::*;
 use std::net::SocketAddr;
 use tokio::net::{TcpListener, TcpStream};
-use tokio_tungstenite::{accept_async, tungstenite::Error};
-use tungstenite::Result;
+use tokio_tungstenite::{accept_async, tungstenite::Error, tungstenite::Result};
 
 async fn accept_connection(peer: SocketAddr, stream: TcpStream) {
     if let Err(e) = handle_connection(peer, stream).await {

--- a/examples/interval-server.rs
+++ b/examples/interval-server.rs
@@ -2,8 +2,9 @@ use futures_util::{SinkExt, StreamExt};
 use log::*;
 use std::{net::SocketAddr, time::Duration};
 use tokio::net::{TcpListener, TcpStream};
-use tokio_tungstenite::{accept_async, tungstenite::Error};
-use tungstenite::{Message, Result};
+use tokio_tungstenite::{
+    accept_async, tungstenite::Error, tungstenite::Message, tungstenite::Result,
+};
 
 async fn accept_connection(peer: SocketAddr, stream: TcpStream) {
     if let Err(e) = handle_connection(peer, stream).await {

--- a/examples/interval-server.rs
+++ b/examples/interval-server.rs
@@ -3,7 +3,8 @@ use log::*;
 use std::{net::SocketAddr, time::Duration};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_tungstenite::{
-    accept_async, tungstenite::Error, tungstenite::Message, tungstenite::Result,
+    accept_async,
+    tungstenite::{Error, Message, Result},
 };
 
 async fn accept_connection(peer: SocketAddr, stream: TcpStream) {

--- a/examples/server-custom-accept.rs
+++ b/examples/server-custom-accept.rs
@@ -39,10 +39,12 @@ use hyper::{
 use futures_channel::mpsc::{unbounded, UnboundedSender};
 use futures_util::{future, pin_mut, stream::TryStreamExt, StreamExt};
 
-use tokio_tungstenite::WebSocketStream;
-use tungstenite::{
-    handshake::derive_accept_key,
-    protocol::{Message, Role},
+use tokio_tungstenite::{
+    tungstenite::{
+        handshake::derive_accept_key,
+        protocol::{Message, Role},
+    },
+    WebSocketStream,
 };
 
 type Tx = UnboundedSender<Message>;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -29,7 +29,7 @@ use futures_channel::mpsc::{unbounded, UnboundedSender};
 use futures_util::{future, pin_mut, stream::TryStreamExt, StreamExt};
 
 use tokio::net::{TcpListener, TcpStream};
-use tungstenite::protocol::Message;
+use tokio_tungstenite::tungstenite::protocol::Message;
 
 type Tx = UnboundedSender<Message>;
 type PeerMap = Arc<Mutex<HashMap<SocketAddr, Tx>>>;


### PR DESCRIPTION
…not depend directly on tungstenite.

(I ran into the same confusion as in: https://github.com/snapview/tokio-tungstenite/issues/141)