### PR TITLE
Removed unused `webpki` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ native-tls = ["native-tls-crate", "tokio-native-tls", "stream", "tungstenite/nat
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored", "tungstenite/native-tls-vendored"]
 rustls-tls-native-roots = ["__rustls-tls", "rustls-native-certs"]
 rustls-tls-webpki-roots = ["__rustls-tls", "webpki-roots"]
-__rustls-tls = ["rustls", "tokio-rustls", "stream", "tungstenite/__rustls-tls", "webpki", "handshake"]
+__rustls-tls = ["rustls", "tokio-rustls", "stream", "tungstenite/__rustls-tls", "handshake"]
 stream = []
 
 [dependencies]
@@ -56,10 +56,6 @@ version = "0.3.1"
 [dependencies.tokio-rustls]
 optional = true
 version = "0.24.0"
-
-[dependencies.webpki]
-optional = true
-version = "0.22.0"
 
 [dependencies.webpki-roots]
 optional = true


### PR DESCRIPTION
It looks like the crate was never used directly, but only via the re-export by `tokio_rustls`. 