### PR TITLE
Revert tokio requirement to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ stream = []
 [dependencies]
 log = "0.4.17"
 futures-util = { version = "0.3.28", default-features = false, features = ["sink", "std"] }
-tokio = { version = "1.27.0", default-features = false, features = ["io-util"] }
+tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
 version = "0.19.0"


### PR DESCRIPTION
See [this comment](https://github.com/snapview/tokio-tungstenite/commit/aed9a089e16aa3bb149fb3f6c3101c200f41cea3#r109076924#r109076924). Updating this dependency breaks consumers of this crate unnecessarily. 