### PR TITLE
Support IPv6 URIs with rustls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,9 @@ where
 #[inline]
 fn domain(request: &tungstenite::handshake::client::Request) -> Result<String, WsError> {
     match request.uri().host() {
+        // rustls expects IPv6 addresses without the surrounding [] brackets
+        #[cfg(feature = "__rustls-tls")]
+        Some(d) if d.starts_with('[') && d.ends_with(']') => Ok(d[1..d.len() - 1].to_string()),
         Some(d) => Ok(d.to_string()),
         None => Err(WsError::Url(tungstenite::error::UrlError::NoHostName)),
     }


### PR DESCRIPTION
When trying to connect to an IPv6 address with the `rustls` feature enabled, the connection fails because `rustls` parses the domain as an `std::net::IPAddr` which expects the IP to not have the square brackets around it e.g. `2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF` instead of `[2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]`. But when providing/parsing an `http::URI` the square brackets are required. 

If we strip the square brackets from the host before passing it to `rustls` the connection works. 

#### Repro snippet:
```
tokio_tungstenite::connect_async("wss://[2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:443").await.expect("to connect");
```