### PR TITLE
Add compiler error when enabling rustls without pki.

### DIFF
--- a/src/tls.rs
+++ b/src/tls.rs
@@ -112,6 +112,11 @@ mod encryption {
                                     })
                                 );
                             }
+                            #[cfg(not(any(
+                                feature = "rustls-tls-native-roots",
+                                feature = "rustls-tls-webpki-roots"
+                            )))]
+                            compile_error!("__rustls-tls is private; use one of the documented flags to choose root certificate vendor");
 
                             Arc::new(
                                 ClientConfig::builder()

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -90,7 +90,6 @@ mod encryption {
                     let config = match tls_connector {
                         Some(config) => config,
                         None => {
-                            #[allow(unused_mut)]
                             let mut root_store = RootCertStore::empty();
                             #[cfg(feature = "rustls-tls-native-roots")]
                             {

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -116,7 +116,7 @@ mod encryption {
                                 feature = "rustls-tls-native-roots",
                                 feature = "rustls-tls-webpki-roots"
                             )))]
-                            compile_error!("__rustls-tls is private; use one of the documented flags to choose root certificate vendor");
+                            compile_error!("__rustls-tls is private; use one of the documented features to choose root certificate vendor");
 
                             Arc::new(
                                 ClientConfig::builder()


### PR DESCRIPTION
Thanks for this library!

This PR makes it impossible to enable the `__rustls-tls` feature on its own, which would have prevented https://github.com/surrealdb/surrealdb/issues/1949

```console
$ cargo check
    Checking tokio-tungstenite v0.19.0 (/home/finnb/git/finnbear/tokio-tungstenite)
    Finished dev [unoptimized + debuginfo] target(s) in 0.20s

$ cargo check --features __rustls-tls
    Checking tokio-tungstenite v0.19.0 (/home/finnb/git/finnbear/tokio-tungstenite)
error: __rustls-tls is private; use one of the documented features to choose root certificate vendor
   --> src/tls.rs:119:29
    |
119 | ...                   compile_error!("__rustls-tls is private; use one of the documented features to choose root certificate vendor");
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `tokio-tungstenite` due to previous error

$ cargo check --features rustls-tls-native-roots
    Checking tokio-tungstenite v0.19.0 (/home/finnb/git/finnbear/tokio-tungstenite)
    Finished dev [unoptimized + debuginfo] target(s) in 0.88s

$ cargo check --features rustls-tls-webpki-roots
    Checking tokio-tungstenite v0.19.0 (/home/finnb/git/finnbear/tokio-tungstenite)
    Finished dev [unoptimized + debuginfo] target(s) in 0.33s
```