### PR TITLE
Remove flush on each WebSocketStream::poll_ready call + update to tungstenite 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ futures-util = { version = "0.3.28", default-features = false, features = ["sink
 tokio = { version = "1.0.0", default-features = false, features = ["io-util"] }
 
 [dependencies.tungstenite]
-version = "0.19.0"
+# TODO use 0.20 release
+# version = "0.19.0"
+git = "https://github.com/snapview/tungstenite-rs"
 default-features = false
 
 [dependencies.native-tls-crate]

--- a/examples/server-headers.rs
+++ b/examples/server-headers.rs
@@ -78,9 +78,9 @@ fn client() {
         debug!("* {}: {:?}", header, _value);
     }
 
-    socket.write_message(Message::Text("Hello WebSocket".into())).unwrap();
+    socket.send(Message::Text("Hello WebSocket".into())).unwrap();
     loop {
-        let msg = socket.read_message().expect("Error reading message");
+        let msg = socket.read().expect("Error reading message");
         debug!("Received: {}", msg);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,8 +321,8 @@ where
 {
     type Error = WsError;
 
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        (*self).with_context(Some((ContextWaker::Write, cx)), |s| cvt(s.write_pending()))
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,8 +290,8 @@ where
         }
 
         match futures_util::ready!(self.with_context(Some((ContextWaker::Read, cx)), |s| {
-            trace!("{}:{} Stream.with_context poll_next -> read_message()", file!(), line!());
-            cvt(s.read_message())
+            trace!("{}:{} Stream.with_context poll_next -> read()", file!(), line!());
+            cvt(s.read())
         })) {
             Ok(v) => Poll::Ready(Some(Ok(v))),
             Err(e) => {
@@ -326,7 +326,7 @@ where
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
-        match (*self).with_context(None, |s| s.write_message(item)) {
+        match (*self).with_context(None, |s| s.write(item)) {
             Ok(()) => Ok(()),
             Err(WsError::Io(err)) if err.kind() == std::io::ErrorKind::WouldBlock => {
                 // the message was accepted and queued
@@ -341,7 +341,7 @@ where
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        (*self).with_context(Some((ContextWaker::Write, cx)), |s| cvt(s.write_pending())).map(|r| {
+        (*self).with_context(Some((ContextWaker::Write, cx)), |s| cvt(s.flush())).map(|r| {
             // WebSocket connection has just been closed. Flushing completed, not an error.
             match r {
                 Err(WsError::ConnectionClosed) => Ok(()),
@@ -352,8 +352,8 @@ where
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let res = if self.closing {
-            // After queueing it, we call `write_pending` to drive the close handshake to completion.
-            (*self).with_context(Some((ContextWaker::Write, cx)), |s| s.write_pending())
+            // After queueing it, we call `flush` to drive the close handshake to completion.
+            (*self).with_context(Some((ContextWaker::Write, cx)), |s| s.flush())
         } else {
             (*self).with_context(Some((ContextWaker::Write, cx)), |s| s.close(None))
         };


### PR DESCRIPTION
My context: I've been working on a websocket load generator service that will write lots of small json message events to it's ws clients. I was interested in having a high peak throughput from this service to allow me to test downstream load performance. It uses axum->tokio-tungstenite->tungstenite. Doing localhost testing I got **~1.2M msg/s** peak throughput. This PR + https://github.com/snapview/tungstenite-rs/pull/357 improves that to **~2M msg/s**.

Currently each `SinkExt::feed` call will call into tungstenite `write_pending` on `poll_ready` meaning flushing before each message write. This is a poor fit for sending lots of small messages where it would be better to be able to `feed` many messages then `flush`.

From `poll_ready` docs:
> This method returns `Poll::Ready` once the underlying sink is ready to receive data.

As tungstenite websockets have a write buffer I believe they are always ready to receive data, and so the impl in this PR simply always returns ready here (without flushing).

Note: Without https://github.com/snapview/tungstenite-rs/pull/357 it actually makes little difference to performance since upstream was also eagerly flushing before each write. So this isn't a big win on it's own. However, if we can agree this impl is more correct I don't see any harm merging before changes upstream.

## Update
Now updated to use tungstenite `0.20` (not yet released).