### PR TITLE
`poll_ready` flush after `WouldBlock` errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,6 +193,11 @@ pub struct WebSocketStream<S> {
     inner: WebSocket<AllowStd<S>>,
     closing: bool,
     ended: bool,
+    /// Tungstenite is probably ready to receive more data.
+    ///
+    /// `false` once start_send hits `WouldBlock` errors.
+    /// `true` initially and after `flush`ing.
+    ready: bool,
 }
 
 impl<S> WebSocketStream<S> {
@@ -226,7 +231,7 @@ impl<S> WebSocketStream<S> {
     }
 
     pub(crate) fn new(ws: WebSocket<AllowStd<S>>) -> Self {
-        WebSocketStream { inner: ws, closing: false, ended: false }
+        Self { inner: ws, closing: false, ended: false, ready: true }
     }
 
     fn with_context<F, R>(&mut self, ctx: Option<(ContextWaker, &mut Context<'_>)>, f: F) -> R
@@ -322,18 +327,27 @@ where
     type Error = WsError;
 
     fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+        if self.ready {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
     }
 
     fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
         match (*self).with_context(None, |s| s.write(item)) {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                self.ready = true;
+                Ok(())
+            }
             Err(WsError::Io(err)) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                // the message was accepted and queued
-                // isn't an error.
+                // the message was accepted and queued so not an error
+                // but `poll_ready` will start returning pending now.
+                self.ready = false;
                 Ok(())
             }
             Err(e) => {
+                self.ready = true;
                 debug!("websocket start_send error: {}", e);
                 Err(e)
             }
@@ -341,6 +355,7 @@ where
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.ready = true;
         (*self).with_context(Some((ContextWaker::Write, cx)), |s| cvt(s.flush())).map(|r| {
             // WebSocket connection has just been closed. Flushing completed, not an error.
             match r {
@@ -351,6 +366,7 @@ where
     }
 
     fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.ready = true;
         let res = if self.closing {
             // After queueing it, we call `flush` to drive the close handshake to completion.
             (*self).with_context(Some((ContextWaker::Write, cx)), |s| s.flush())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ where
             }
             Err(WsError::Io(err)) if err.kind() == std::io::ErrorKind::WouldBlock => {
                 // the message was accepted and queued so not an error
-                // but `poll_ready` will start returning pending now.
+                // but `poll_ready` will now start trying to flush the block
                 self.ready = false;
                 Ok(())
             }


### PR DESCRIPTION
With this PR `poll_ready` continues to generally return `Ready`. However, after `start_send` encounters `WouldBlock` `poll_ready` will instead try to flush.

When poll_ready->flush returns `Ready` poll_ready will revert to just returning `Ready` ... until the next `WouldBlock`.

This mechanism prevents the case tokio-tungstenite users filling up the tungstenite write-buffer without actually handling any errors (since `WouldBlock` errors are not returned to the user).

We also maintains `feed` generally _not_ flushing as it will only do so after encountering `WouldBlock` errors. So should perform well.

See https://github.com/snapview/tokio-tungstenite/issues/286#issuecomment-1595678753.

Resolves #286 

## Questions/alternatives
* We could do a similar thing by checking if the write-buffer is fuller than `WebSocketConfig::write_buffer_size`. I think this would achieve the same thing though it would require some changes upstream to expose the current write-buffer size. I'm not sure it's actually better than just tracking would-block as this PR does though.
* I initially just had `poll_ready` simply return `Pending` after `WouldBlock` but trying to flush in this case seems more correct & useful, plus seems to fit with the `Sink` docs
    > Implementations of `poll_ready` and `start_send` will usually involve flushing behind the scenes in order to make room for new messages. It is only necessary to call `poll_flush` if you need to guarantee that *all* of the items placed into the `Sink` have been sent.