### PR TITLE
Update `rustls` to 0.22, `tokio-rustls` and related deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ version = "0.24.1"
 
 [dependencies.webpki-roots]
 optional = true
-version = "0.25.2"
+version = "0.26.0"
 
 [dev-dependencies]
 futures-channel = "0.3.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ native-tls = ["native-tls-crate", "tokio-native-tls", "stream", "tungstenite/nat
 native-tls-vendored = ["native-tls", "native-tls-crate/vendored", "tungstenite/native-tls-vendored"]
 rustls-tls-native-roots = ["__rustls-tls", "rustls-native-certs"]
 rustls-tls-webpki-roots = ["__rustls-tls", "webpki-roots"]
-__rustls-tls = ["rustls", "tokio-rustls", "stream", "tungstenite/__rustls-tls", "handshake"]
+__rustls-tls = ["rustls", "rustls-pki-types", "tokio-rustls", "stream", "tungstenite/__rustls-tls", "handshake"]
 stream = []
 
 [dependencies]
@@ -43,11 +43,15 @@ version = "0.2.11"
 
 [dependencies.rustls]
 optional = true
-version = "0.21.6"
+version = "0.22.0"
+
+[dependencies.rustls-pki-types]
+optional = true
+version = "1.0"
 
 [dependencies.rustls-native-certs]
 optional = true
-version = "0.6.2"
+version = "0.7.0"
 
 [dependencies.tokio-native-tls]
 optional = true
@@ -55,7 +59,7 @@ version = "0.3.1"
 
 [dependencies.tokio-rustls]
 optional = true
-version = "0.24.1"
+version = "0.25.0"
 
 [dependencies.webpki-roots]
 optional = true

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -65,7 +65,8 @@ mod encryption {
     #[cfg(feature = "__rustls-tls")]
     pub mod rustls {
         pub use rustls::ClientConfig;
-        use rustls::{RootCertStore, ServerName};
+        use rustls::RootCertStore;
+        use rustls_pki_types::ServerName;
         use tokio_rustls::TlsConnector as TokioTlsConnector;
 
         use std::{convert::TryFrom, sync::Arc};
@@ -95,36 +96,26 @@ mod encryption {
                             #[cfg(feature = "rustls-tls-native-roots")]
                             {
                                 let native_certs = rustls_native_certs::load_native_certs()?;
-                                let der_certs: Vec<Vec<u8>> =
-                                    native_certs.into_iter().map(|cert| cert.0).collect();
-                                let total_number = der_certs.len();
+                                let total_number = native_certs.len();
                                 let (number_added, number_ignored) =
-                                    root_store.add_parsable_certificates(&der_certs);
+                                    root_store.add_parsable_certificates(native_certs);
                                 log::debug!("Added {number_added}/{total_number} native root certificates (ignored {number_ignored})");
                             }
                             #[cfg(feature = "rustls-tls-webpki-roots")]
                             {
-                                root_store.add_trust_anchors(
-                                    webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
-                                        rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-                                            ta.subject.as_ref(),
-                                            ta.subject_public_key_info.as_ref(),
-                                            ta.name_constraints.as_deref(),
-                                        )
-                                    })
-                                );
+                                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
                             }
 
                             Arc::new(
                                 ClientConfig::builder()
-                                    .with_safe_defaults()
                                     .with_root_certificates(root_store)
                                     .with_no_client_auth(),
                             )
                         }
                     };
                     let domain = ServerName::try_from(domain.as_str())
-                        .map_err(|_| TlsError::InvalidDnsName)?;
+                        .map_err(|_| TlsError::InvalidDnsName)?
+                        .to_owned();
                     let stream = TokioTlsConnector::from(config);
                     let connected = stream.connect(domain, socket).await;
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -107,9 +107,9 @@ mod encryption {
                                 root_store.add_trust_anchors(
                                     webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
                                         rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-                                            ta.subject,
-                                            ta.spki,
-                                            ta.name_constraints,
+                                            ta.subject.as_ref(),
+                                            ta.subject_public_key_info.as_ref(),
+                                            ta.name_constraints.as_deref(),
                                         )
                                     })
                                 );


### PR DESCRIPTION
It needs a new `tungstenite` release with https://github.com/snapview/tungstenite-rs/pull/394 to fully update to `rustls` 0.22.