### PR TITLE
Additional Documentation of `IntoClientRequest` on `connect_async`

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -16,23 +16,17 @@ use crate::{domain, stream::MaybeTlsStream, Connector, IntoClientRequest, WebSoc
 /// complex uses.
 ///
 /// ```no_run
-/// # async fn example() {
+/// # use tungstenite::client::IntoClientRequest;
+///
+/// # async fn main() {
 /// use tungstenite::http::{Method, Request};
 /// use tokio_tungstenite::connect_async;
 ///
-/// let request = Request::builder()
-///             .uri("wss://api.example.com")
-///             .method(Method::GET)
-///             .header("Sec-WebSocket-Key", "someUniqueValue")
-///             .header("Sec-WebSocket-Version", "13")
-///             .header("host", "api.example.com")
-///             .header("Connection", "Upgrade")
-///             .header("Upgrade", "websocket")
-///             .body(())
-///             .unwrap();
+/// let mut request = "wss://api.example.com".into_client_request().unwrap();
+/// request.headers_mut().insert("api-key", "42".parse().unwrap());
 ///
 /// let (stream, response) = connect_async(request).await.unwrap();
-/// #}
+/// # }
 /// ```
 pub async fn connect_async<R>(
     request: R,

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -18,7 +18,7 @@ use crate::{domain, stream::MaybeTlsStream, Connector, IntoClientRequest, WebSoc
 /// ```no_run
 /// # use tungstenite::client::IntoClientRequest;
 ///
-/// # async fn main() {
+/// # async fn test() {
 /// use tungstenite::http::{Method, Request};
 /// use tokio_tungstenite::connect_async;
 ///

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -16,6 +16,7 @@ use crate::{domain, stream::MaybeTlsStream, Connector, IntoClientRequest, WebSoc
 /// complex uses.
 ///
 /// ```no_run
+/// # async fn example() {
 /// use tungstenite::http::{Method, Request};
 /// use tokio_tungstenite::connect_async;
 ///
@@ -31,6 +32,7 @@ use crate::{domain, stream::MaybeTlsStream, Connector, IntoClientRequest, WebSoc
 ///             .unwrap();
 ///
 /// let (stream, response) = connect_async(request).await.unwrap();
+/// #}
 /// ```
 pub async fn connect_async<R>(
     request: R,

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -10,6 +10,28 @@ use tungstenite::{
 use crate::{domain, stream::MaybeTlsStream, Connector, IntoClientRequest, WebSocketStream};
 
 /// Connect to a given URL.
+///
+/// Accepts any request that implements [`IntoClientRequest`], which is often just `&str`, but can
+/// be a variety of types such as `httparse::Request` or [`tungstenite::http::Request`] for more
+/// complex uses.
+///
+/// ```no_run
+/// use tungstenite::http::{Method, Request};
+/// use tokio_tungstenite::connect_async;
+///
+/// let request = Request::builder()
+///             .uri("wss://api.example.com")
+///             .method(Method::GET)
+///             .header("Sec-WebSocket-Key", "someUniqueValue")
+///             .header("Sec-WebSocket-Version", "13")
+///             .header("host", "api.example.com")
+///             .header("Connection", "Upgrade")
+///             .header("Upgrade", "websocket")
+///             .body(())
+///             .unwrap();
+///
+/// let (stream, response) = connect_async(request).await.unwrap();
+/// ```
 pub async fn connect_async<R>(
     request: R,
 ) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), Error>


### PR DESCRIPTION
I came across https://github.com/snapview/tokio-tungstenite/issues/92 when I needed this behavior for a use case of mine and wanted to save future searchers the trouble with an explicit example in the docs. 

Let me know if there's anything I can change. My IDE didn't seem pleased with the formatting, even when adding the hidden `async fn example() { ... }` around it.