### PR TITLE
deps: update `rustls-native-certs` to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ version = "1.0"
 
 [dependencies.rustls-native-certs]
 optional = true
-version = "0.7.0"
+version = "0.8.0"
 
 [dependencies.tokio-native-tls]
 optional = true

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -95,10 +95,26 @@ mod encryption {
                             let mut root_store = RootCertStore::empty();
                             #[cfg(feature = "rustls-tls-native-roots")]
                             {
-                                let native_certs = rustls_native_certs::load_native_certs()?;
-                                let total_number = native_certs.len();
+                                let rustls_native_certs::CertificateResult {
+                                    certs, errors, ..
+                                } = rustls_native_certs::load_native_certs();
+
+                                if !errors.is_empty() {
+                                    log::warn!(
+                                        "native root CA certificate loading errors: {errors:?}"
+                                    );
+                                }
+
+                                // Not finding any native root CA certificates is not fatal if the
+                                // "rustls-tls-webpki-roots" feature is enabled.
+                                #[cfg(not(feature = "rustls-tls-webpki-roots"))]
+                                if certs.is_empty() {
+                                    return Err(std::io::Error::new(std::io::ErrorKind::NotFound, format!("no native root CA certificates found (errors: {errors:?})")).into());
+                                }
+
+                                let total_number = certs.len();
                                 let (number_added, number_ignored) =
-                                    root_store.add_parsable_certificates(native_certs);
+                                    root_store.add_parsable_certificates(certs);
                                 log::debug!("Added {number_added}/{total_number} native root certificates (ignored {number_ignored})");
                             }
                             #[cfg(feature = "rustls-tls-webpki-roots")]


### PR DESCRIPTION
The `load_native_certs()` function now returns all errors instead of raising only the first error.

Not finding any native root CA certificates is not fatal if the "rustls-tls-webpki-roots" feature is enabled.