### PR TITLE
Implement into_inner to get the underlying stream

### DIFF
--- a/src/compat.rs
+++ b/src/compat.rs
@@ -96,6 +96,11 @@ impl<S> AllowStd<S> {
             }
         }
     }
+
+    /// Returns the underlying stream.
+    pub(crate) fn into_inner(self) -> S {
+        self.inner
+    }
 }
 
 // Proxy Waker that we pass to the internal AsyncRead/Write of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,6 +247,11 @@ impl<S> WebSocketStream<S> {
         f(&mut self.inner)
     }
 
+    /// Consumes the `WebSocketStream` and returns the underlying stream.
+    pub fn into_inner(self) -> S {
+        self.inner.into_inner().into_inner()
+    }
+
     /// Returns a shared reference to the inner stream.
     pub fn get_ref(&self) -> &S
     where


### PR DESCRIPTION
Followup to the analogous change in tungstenite (https://github.com/snapview/tungstenite-rs/pull/516) to get the underlying raw stream from a WebSocketStream.


There's an argument that into_inner on the `WebSocketStream` should return the `WebSocket` and then consumers call into_inner again, but that wraps AllowStd which is not public so I decide to return the underlying stream only which I think is fine.


This is a bit of an odd pull request in that it doesn't compile because a new version of tungstenite hasn't been cut yet. Once `tungstenite = 0.28` is cut, hopefully this can be merged and be part of `tokio-tungstenite = 0.28`