### PR TITLE
chore: improve tokio-tungstenite maintenance path

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -91,3 +91,31 @@ impl<S: AsyncRead + AsyncWrite + Unpin> AsyncWrite for MaybeTlsStream<S> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake};
+    use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, ReadBuf};
+
+    struct DummyWaker;
+    impl Wake for DummyWaker {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    #[tokio::test]
+    async fn plain_stream_forwards_pending_and_eof() {
+        let (client, mut server) = duplex(64);
+        let mut stream = MaybeTlsStream::Plain(client);
+        let waker = Arc::new(DummyWaker).into();
+        let mut cx = Context::from_waker(&waker);
+        let mut buf = [0u8; 4];
+        let mut read_buf = ReadBuf::new(&mut buf);
+        assert!(matches!(Pin::new(&mut stream).poll_read(&mut cx, &mut read_buf), Poll::Pending));
+        server.write_all(b"x").await.unwrap();
+        assert_eq!(stream.read(&mut buf).await.unwrap(), 1);
+        drop(server);
+        assert_eq!(stream.read(&mut buf).await.unwrap(), 0);
+    }
+}

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -235,3 +235,17 @@ where
 
     client_async_with_config(request, stream, config).await
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use tungstenite::error::UrlError;
+
+    #[tokio::test]
+    async fn plain_connector_rejects_wss() {
+        let stream = Cursor::new(vec![]);
+        let result = client_async_tls_with_config("wss://example.com/", stream, None, Some(Connector::Plain)).await;
+        assert!(matches!(result, Err(Error::Url(UrlError::TlsFeatureNotEnabled))));
+    }
+}


### PR DESCRIPTION
Summary:
- Add small, self-contained unit tests for the existing helper logic in src/tls.rs and src/stream.rs that don't require live network I/O — for example, assert that the Connector::Plain variant correctly reports/handles a wss:// scheme (no silent acceptance) and that MaybeTlsStream's poll wiring on a constructed Plain stream forwards EOF and pending states from an in-memory io::Cursor / tokio::io::duplex pair as expected. Keep both tests under ~30 lines each, gated by existing feature flags only if needed.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.