### PR TITLE
Document cancel safety of reading from WebSocketStream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,18 @@ where
 /// through the respective `Stream` and `Sink`. Check more information about
 /// them in `futures-rs` crate documentation or have a look on the examples
 /// and unit tests for this crate.
+///
+/// # Cancel safety
+///
+/// Reading messages is cancel-safe. `WebSocketStream` has no dedicated read
+/// methods; messages arrive through its `Stream` implementation, and reading a
+/// message via `StreamExt::next` follows that trait's cancel-safety: if the
+/// `next()` future is dropped before it resolves (for example, as a branch of
+/// `tokio::select!` that another branch completes first), no message is lost.
+/// The next poll resumes from the same position in the stream.
+///
+/// The `Sink` side (sending) does not carry a documented cancel-safety
+/// guarantee.
 #[derive(Debug)]
 pub struct WebSocketStream<S> {
     inner: WebSocket<AllowStd<S>>,


### PR DESCRIPTION
Closes #359.

In #359 you confirmed that reading messages via the `Stream` / `StreamExt` implementation is cancel-safe and noted you were open to documenting it. This adds that to the `WebSocketStream` rustdoc so it is discoverable without searching the issue tracker.

The wording follows your framing from the thread: `WebSocketStream` has no dedicated read methods, so reading via `StreamExt::next` inherits that trait's cancel-safety rather than tokio-tungstenite defining its own. It also notes that the `Sink` (sending) side carries no documented guarantee, without claiming it is or is not safe.

Verified with `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`.

### Motivation

Downstream, axum is documenting cancel-safety of `WebSocket::recv` (tokio-rs/axum#3282, tokio-rs/axum#3780). A reviewer rightly pushed back that axum should not promise a guarantee that rests on undocumented upstream behavior. Documenting it here gives downstreams a real contract to cite.
