### PR TITLE
Add WebSocketStream::into_inner_with_read_buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+- Add `WebSocketStream::into_inner_with_read_buffer()` so that a caller taking over the raw stream after the handshake can recover bytes the peer coalesced into the same read as the handshake response, which `into_inner()` discards. Requires `tungstenite` with `WebSocket::into_inner_with_read_buffer()` (snapview/tungstenite-rs#556).
+
 # 0.29.0
 
 - Update `tungstenite` to `0.29.0`. See [`tungstenite` release](https://github.com/snapview/tungstenite-rs/blob/master/CHANGELOG.md).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,22 @@ impl<S> WebSocketStream<S> {
         self.inner.into_inner().into_inner()
     }
 
+    /// Consumes the `WebSocketStream` and returns the underlying stream together
+    /// with any bytes that were already read from it into the internal read
+    /// buffer but not yet consumed as a WebSocket message.
+    ///
+    /// Unlike [`WebSocketStream::into_inner`], this does not discard that
+    /// buffered data. It is useful when taking over the raw stream after the
+    /// handshake — for example to relay raw bytes — where the peer may have
+    /// coalesced WebSocket frame bytes into the same read as the handshake
+    /// response (or where some frames have already been read and a tail
+    /// remains). The returned buffer precedes anything still unread on the
+    /// returned stream.
+    pub fn into_inner_with_read_buffer(self) -> (S, tungstenite::Bytes) {
+        let (allow_std, buffer) = self.inner.into_inner_with_read_buffer();
+        (allow_std.into_inner(), buffer)
+    }
+
     /// Returns a shared reference to the inner stream.
     pub fn get_ref(&self) -> &S
     where

--- a/tests/into_inner_with_read_buffer.rs
+++ b/tests/into_inner_with_read_buffer.rs
@@ -1,0 +1,55 @@
+//! Regression test for [`WebSocketStream::into_inner_with_read_buffer`].
+
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio_tungstenite::{tungstenite::protocol::Role, WebSocketStream};
+
+/// A no-op async stream: reads report EOF and writes are accepted and
+/// discarded. Enough to construct a `WebSocketStream` without any real
+/// handshake I/O, and it is never read by `into_inner_with_read_buffer`.
+struct NullStream;
+
+impl AsyncRead for NullStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        _: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncWrite for NullStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test]
+async fn into_inner_with_read_buffer_recovers_coalesced_bytes() {
+    // Model a server that coalesced a WebSocket frame into the same read as the
+    // `101 Switching Protocols` response: `from_partially_read` seeds those
+    // bytes into the codec read buffer. They must survive a raw takeover of the
+    // stream, which plain `into_inner()` discards.
+    let coalesced = vec![0x82u8, 0x03, 0x01, 0x02, 0x03];
+    let ws =
+        WebSocketStream::from_partially_read(NullStream, coalesced.clone(), Role::Client, None)
+            .await;
+    let (_stream, buffer) = ws.into_inner_with_read_buffer();
+    assert_eq!(&buffer[..], &coalesced[..]);
+}


### PR DESCRIPTION
Addresses #379.

> [!NOTE]
> **Depends on tungstenite.** This delegates to `tungstenite::WebSocket::into_inner_with_read_buffer()` from snapview/tungstenite-rs#556, which isn't released yet. It will build once that lands and the `tungstenite` dependency is bumped to the release containing it. Opened now so the full chain is visible and reviewable.

### Problem

`WebSocketStream::into_inner()` returns only the underlying stream and discards the tungstenite frame codec's read buffer. Taking over the raw stream after the handshake (e.g. to relay raw bytes) therefore loses bytes the peer coalesced into the same read as the handshake response — or an unread frame tail. See #379.

### Change

```rust
pub fn into_inner_with_read_buffer(self) -> (S, tungstenite::Bytes) {
    let (allow_std, buffer) = self.inner.into_inner_with_read_buffer();
    (allow_std.into_inner(), buffer)
}
```

A thin wrapper over the new tungstenite accessor: it unwraps `AllowStd` (mirroring `into_inner()`'s `self.inner.into_inner().into_inner()`) and returns the codec's not-yet-consumed read buffer alongside the stream. `tungstenite::Bytes` is already re-exported (`pub use tungstenite;`), so no new dependency. `into_inner()` is unchanged.

### Tests

`tests/into_inner_with_read_buffer.rs` constructs a `WebSocketStream` via `from_partially_read` (modelling a coalesced post-handshake segment over a no-op async stream) and asserts the bytes are returned, not dropped.

Verified locally against the tungstenite branch via a `[patch.crates-io]` override (not committed): the test passes; `cargo fmt` is clean. CHANGELOG updated under a new UNRELEASED section.

### Why

Upstream blocker for a lossless raw-stream takeover after a WebSocket handshake — e.g. a proxy/gateway tunnel mode that completes the handshake then bypasses framing to relay raw bytes.